### PR TITLE
add bcrypt support

### DIFF
--- a/dataprovider/dataprovider.go
+++ b/dataprovider/dataprovider.go
@@ -22,6 +22,7 @@ const (
 
 	logSender                = "dataProvider"
 	argonPwdPrefix           = "$argon2id$"
+	bcryptPwdPrefix          = "$2a$"
 	manageUsersDisabledError = "please set manage_users to 1 in sftpgo.conf to enable this method"
 	trackQuotaDisabledError  = "please enable track_quota in sftpgo.conf to use this method"
 )

--- a/dataprovider/sqlcommon.go
+++ b/dataprovider/sqlcommon.go
@@ -10,6 +10,8 @@ import (
 	"golang.org/x/crypto/ssh"
 
 	"github.com/alexedwards/argon2id"
+	"golang.org/x/crypto/bcrypt"
+
 	"github.com/drakkan/sftpgo/logger"
 	"github.com/drakkan/sftpgo/utils"
 )
@@ -43,6 +45,15 @@ func sqlCommonValidateUserAndPass(username string, password string) (User, error
 			if err != nil {
 				logger.Warn(logSender, "error comparing password with argon hash: %v", err)
 				return user, err
+			}
+
+		} else if strings.HasPrefix(user.Password, bcryptPwdPrefix){
+			err = bcrypt.CompareHashAndPassword([]byte(user.Password), []byte(password))
+			if err != nil {
+				logger.Warn(logSender, "error comparing password with bcrypt hash: %v", err)
+				return user, err
+			}else{
+				match = true
 			}
 		} else {
 			// clear text password match


### PR DESCRIPTION
as requested in https://github.com/pilif/sftpgo/commit/32192ce7b8515ef842f292ba6c7923a43235867e#commitcomment-34468602, this adds support to the bcrypt password encoding scheme when authenticating users.

Creating new users still uses Argon2i which is objectively better than bcrypt, but bcrypt is more widely used and thus some sites might still be stuck with bcrypt.