### PR TITLE
make the server banner configurable

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -28,6 +28,7 @@ func init() {
 	// create a default configuration to use if no config file is provided
 	globalConf = globalConfig{
 		SFTPD: sftpd.Configuration{
+			Banner:       "SFTPServer",
 			BindPort:     2022,
 			BindAddress:  "",
 			IdleTimeout:  15,

--- a/sftpd/server.go
+++ b/sftpd/server.go
@@ -27,6 +27,7 @@ import (
 
 // Configuration server configuration
 type Configuration struct {
+	Banner       string  `json:"banner"`
 	BindPort     int     `json:"bind_port"`
 	BindAddress  string  `json:"bind_address"`
 	IdleTimeout  int     `json:"idle_timeout"`
@@ -63,7 +64,7 @@ func (c Configuration) Initialize(configDir string) error {
 
 			return sp, nil
 		},
-		ServerVersion: "SSH-2.0-SFTPServer",
+		ServerVersion: "SSH-2.0-" + c.Banner,
 	}
 
 	if _, err := os.Stat(filepath.Join(configDir, "id_rsa")); os.IsNotExist(err) {


### PR DESCRIPTION
as requested in https://github.com/pilif/sftpgo/commit/3ffe4a35fcf9300af82e1f3bcce89702c06b136d#commitcomment-34468605, this commit allows the user to configure the identification string used by the server. 

This is mostly a matter of vanity. I know of no real SSH client that's actually displaying this, but in my case, I felt like showing off :p