### PR TITLE
Add missing newline, add code highlighting hint

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,8 @@ The `sftpgo.conf` configuration file contains the following sections:
 
 Here is a full example showing the default config:
 
-```{
+```json
+{
    "sftpd":{
         "bind_port":2022,
         "bind_address":"",


### PR DESCRIPTION
The README as shown on Github missed a leading curly brace. This is fixed with this PR