### PR TITLE
When path starts with slash, consider it absolute

### DIFF
--- a/dataprovider/sqlite.go
+++ b/dataprovider/sqlite.go
@@ -18,7 +18,10 @@ func initializeSQLiteProvider(basePath string) error {
 	var err error
 	var connectionString string
 	if len(config.ConnectionString) == 0 {
-		dbPath := filepath.Join(basePath, config.Name)
+		dbPath := config.Name
+		if !filepath.IsAbs(dbPath) {
+			dbPath = filepath.Join(basePath, dbPath)
+		}
 		fi, err := os.Stat(dbPath)
 		if err != nil {
 			logger.Warn(logSender, "sqlite database file does not exists, please be sure to create and initialize"+


### PR DESCRIPTION
When SQLite path starts with a `/`, we consider this to be an absolute path.

Eg.:

```json
{
  "data_provider":{
    "name":"/var/lib/sftpgo/sftpgo.db"
  }
}
```

(This should maybe be reflected in the documentation?)