### PR TITLE
Add Environment & EnvironmentFile directives

### DIFF
--- a/init/sftpgo.service
+++ b/init/sftpgo.service
@@ -7,7 +7,10 @@ User=root
 Group=root
 Type=simple
 WorkingDirectory=/etc/sftpgo
-ExecStart=/usr/bin/sftpgo --config-dir /etc/sftpgo --log-file-path /var/log/sftpgo.log
+Environment=SFTPGO_CONFIG_DIR=/etc/sftpgo/
+Environment=SFTPGO_LOG_FILE_PATH=/var/log/sftpgo.log
+EnvironmentFile=-/etc/sftpgo/sftpgo.env
+ExecStart=/usr/bin/sftpgo
 KillMode=mixed
 Restart=always
 RestartSec=10s


### PR DESCRIPTION
Since we can now override settings through environment variables, it's handy to contain those changes in a separate file. This way, sysadmins can generate such a file without having to touch the systemd file.

Meanwhile the current flags are converted to `Environment` entries, which can be overridden in the `EnvironmentFile` if so desired.

If the file is not present, the directive [is ignored](https://www.freedesktop.org/software/systemd/man/systemd.exec.html#EnvironmentFile=)