### PR TITLE
Log to journald

### DIFF
--- a/init/sftpgo.service
+++ b/init/sftpgo.service
@@ -8,7 +8,7 @@ Group=root
 Type=simple
 WorkingDirectory=/etc/sftpgo
 Environment=SFTPGO_CONFIG_DIR=/etc/sftpgo/
-Environment=SFTPGO_LOG_FILE_PATH=/var/log/sftpgo.log
+Environment=SFTPGO_LOG_FILE_PATH=
 EnvironmentFile=-/etc/sftpgo/sftpgo.env
 ExecStart=/usr/bin/sftpgo serve
 KillMode=mixed


### PR DESCRIPTION
By default on systems with systemd, send logs to stdout and thus to journald.