### PR TITLE
Add systemD/journalD sftpgo Fail2ban configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -513,7 +513,9 @@ The logs can be divided into the following categories:
     - `login_type` string. Can be `public_key`, `password` or `no_auth_tryed`
     - `error` string. Optional error description
 
-The **connection failed logs** can be used for better integration in tools such as [Fail2ban](http://www.fail2ban.org/)
+### Brute force protection
+
+The **connection failed logs** can be used for better integration in tools such as [Fail2ban](http://www.fail2ban.org/). Example of [jails](./fail2ban/jails) and [filters](./fail2ban/filters) working with systemD/journalD are available in fail2ban directory.
 
 ## Acknowledgements
 

--- a/fail2ban/filters/sftpgo.conf
+++ b/fail2ban/filters/sftpgo.conf
@@ -1,0 +1,15 @@
+[INCLUDES]
+before = common.conf
+
+[DEFAULT]
+_daemon = sftpgo
+
+[Definition]
+
+# By default, first authenticate method is public_key and must be excluded from the filter to avoid false positives failed attemps 
+failregex = ^.*"sender":"connection_failed","client_ip":"<HOST>","username":".*","login_type":"password".*"}$
+
+ignoreregex =
+
+[Init]
+journalmatch = _SYSTEMD_UNIT=sftpgo.service + _COMM=sftpgo

--- a/fail2ban/jails/sftpgo.conf
+++ b/fail2ban/jails/sftpgo.conf
@@ -1,0 +1,10 @@
+[sftpgo]
+enabled = true
+port = 2022
+filter = sftpgo
+action = iptables-allports[name=sftpgo]
+logpath = 
+backend = systemd
+maxretry = 5
+bantime = 600
+findtime = 86400


### PR DESCRIPTION
Hello Drakkan, 

It's the first example of fail2ban configuration for sftpgo working with SystemD/JournalD.
```
~ # fail2ban-client status sftpgo                            
Status for the jail: sftpgo
|- Filter
|  |- Currently failed: 1
|  |- Total failed:     23
|  `- Journal matches:  _SYSTEMD_UNIT=sftpgo.service + _COMM=sftpgo
`- Actions
   |- Currently banned: 1
   |- Total banned:     4
   `- Banned IP list:   197.248.10.108
```
Tested under real conditions :D
The filter can be improved.

