### PR TITLE
CA certificate for Debian Docker image

### DIFF
--- a/docker/sftpgo/debian/Dockerfile
+++ b/docker/sftpgo/debian/Dockerfile
@@ -10,8 +10,8 @@ RUN go build -i -ldflags "-s -w -X github.com/drakkan/sftpgo/utils.commit=`git d
 # now define the run environment
 FROM debian:latest
 
-# git and rsync are optional, uncomment the next line to add support for them if needed
-#RUN apt-get update && apt-get install -y git rsync
+# git, rsync and ca-certificates are optional, uncomment the next line to add support for them if needed. (ca-certificate if you're going to use S3 binding feature)
+RUN apt-get update && apt-get install -y git rsync ca-certificates
 
 ARG BASE_DIR=/app
 ARG DATA_REL_DIR=data

--- a/docker/sftpgo/debian/Dockerfile
+++ b/docker/sftpgo/debian/Dockerfile
@@ -11,7 +11,7 @@ RUN go build -i -ldflags "-s -w -X github.com/drakkan/sftpgo/utils.commit=`git d
 FROM debian:latest
 
 # git, rsync and ca-certificates are optional, uncomment the next line to add support for them if needed. (ca-certificate if you're going to use S3 binding feature)
-RUN apt-get update && apt-get install -y git rsync ca-certificates
+#RUN apt-get update && apt-get install -y git rsync ca-certificates
 
 ARG BASE_DIR=/app
 ARG DATA_REL_DIR=data


### PR DESCRIPTION
Since SFTPGo is an SLL based application, it requires an CA signed certificate to be able to authenticate an SSL connection with AWS. 
This PR includes a package installation instruction which will provide to the Debian image a group CA certificates, so it will be possible to make SSL connections with AWS endpoints while using the S3 binding feature.