### PR TITLE
portable: set data_provider.name to empty

### DIFF
--- a/service/service.go
+++ b/service/service.go
@@ -150,6 +150,7 @@ func (s *Service) StartPortableMode(sftpdPort int, enabledSSHCommands []string, 
 	}
 	dataProviderConf := config.GetProviderConf()
 	dataProviderConf.Driver = dataprovider.MemoryDataProviderName
+	dataProviderConf.Name = ""
 	dataProviderConf.CredentialsPath = filepath.Join(os.TempDir(), "credentials")
 	config.SetProviderConf(dataProviderConf)
 	httpdConf := config.GetHTTPDConfig()


### PR DESCRIPTION
Default `data_provider.name` is `sftpgo.db`. Even if driver is `memory`, it checks existence of `sftpgo.db` file.

I set `data_provider.name` to empty string when start portable mode.

Fixes #73