### PR TITLE
docker: remove serve command from entrypoint in alpine

### DIFF
--- a/docker/sftpgo/alpine/Dockerfile
+++ b/docker/sftpgo/alpine/Dockerfile
@@ -28,4 +28,4 @@ VOLUME [ "/data", "/srv/sftpgo/config", "/srv/sftpgo/backups" ]
 EXPOSE 2022 8080
 
 ENTRYPOINT ["/bin/entrypoint.sh"]
-CMD []
+CMD ["serve"]

--- a/docker/sftpgo/alpine/docker-entrypoint.sh
+++ b/docker/sftpgo/alpine/docker-entrypoint.sh
@@ -4,4 +4,4 @@ set -eu
 
 chown -R "${PUID}:${GUID}" /data /etc/sftpgo /srv/sftpgo/config /srv/sftpgo/backups \
 	&& exec su-exec "${PUID}:${GUID}" \
-  /bin/sftpgo serve "$@"
+  /bin/sftpgo "$@"


### PR DESCRIPTION
It allows to start docker with other commands such as `portable`

`docker run ... sftpgo portable`