### PR TITLE
s3: enable shared config state

### DIFF
--- a/README.md
+++ b/README.md
@@ -530,7 +530,12 @@ SFTPGo uses multipart uploads and parallel downloads for storing and retrieving 
 
 The configured bucket must exist.
 
-To connect SFTPGo to AWS you need [Access Keys](https://docs.aws.amazon.com/general/latest/gr/aws-sec-cred-types.html#access-keys-and-secret-access-keys), a `region` is required too, here is the list of available [AWS regions](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/using-regions-availability-zones.html#concepts-available-regions). For example if your bucket is at `Frankfurt` you have to set the region to `eu-central-1`. You can specify an AWS [storage class](https://docs.aws.amazon.com/AmazonS3/latest/dev/storage-class-intro.html) too, leave blank to use the default AWS storage class. An endpoint is required if you are connecting to a Compatible AWS Storage such as [MinIO](https://min.io/).
+To connect SFTPGo to AWS you need to specify credentials, and a `region` is required too, here is the list of available [AWS regions](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/using-regions-availability-zones.html#concepts-available-regions). For example if your bucket is at `Frankfurt` you have to set the region to `eu-central-1`. You can specify an AWS [storage class](https://docs.aws.amazon.com/AmazonS3/latest/dev/storage-class-intro.html) too, leave blank to use the default AWS storage class. An endpoint is required if you are connecting to a Compatible AWS Storage such as [MinIO](https://min.io/).
+
+AWS SDK for Go has different options for credentials. [More Detail](https://docs.aws.amazon.com/sdk-for-go/v1/developer-guide/configuring-sdk.html)
+1. Providing [Access Keys](https://docs.aws.amazon.com/general/latest/gr/aws-sec-cred-types.html#access-keys-and-secret-access-keys).  
+2. Use IAM roles for Amazon EC2 
+3. Use IAM roles for tasks if your application uses an ECS task definition
 
 Some SFTP commands doesn't work over S3:
 

--- a/vfs/vfs.go
+++ b/vfs/vfs.go
@@ -77,12 +77,6 @@ func ValidateS3FsConfig(config *S3FsConfig) error {
 	if len(config.Region) == 0 {
 		return errors.New("region cannot be empty")
 	}
-	if len(config.AccessKey) == 0 {
-		return errors.New("access_key cannot be empty")
-	}
-	if len(config.AccessSecret) == 0 {
-		return errors.New("access_secret cannot be empty")
-	}
 	if len(config.KeyPrefix) > 0 {
 		if strings.HasPrefix(config.KeyPrefix, "/") {
 			return errors.New("key_prefix cannot start with /")


### PR DESCRIPTION
If `sftpgo` is running on an Amazon EC2 instance, it needs to use IAM roles.
It doesn't have explicit access token on EC2 instance. 

`AWS SDK for Go` has ability to use shared config state. It's recommend method for EC2 instances on `Specifying Credentials` section of [documentation](https://docs.aws.amazon.com/sdk-for-go/v1/developer-guide/configuring-sdk.html)