### PR TITLE
[WIP] Add support for dynamic, semi-virtual filesystem

### DIFF
--- a/dataprovider/dataprovider.go
+++ b/dataprovider/dataprovider.go
@@ -606,6 +606,10 @@ func saveGCSCredentials(user *User) error {
 }
 
 func validateFilesystemConfig(user *User) error {
+	if user.FsConfig.Provider == 2 {
+		user.FsConfig.S3Config = vfs.S3FsConfig{}
+		return nil
+	}
 	if user.FsConfig.Provider == 1 {
 		err := vfs.ValidateS3FsConfig(&user.FsConfig.S3Config)
 		if err != nil {

--- a/dataprovider/user.go
+++ b/dataprovider/user.go
@@ -65,10 +65,14 @@ type UserFilters struct {
 
 // Filesystem defines cloud storage filesystem details
 type Filesystem struct {
-	// 0 local filesystem, 1 Amazon S3 compatible, 2 Google Cloud Storage
-	Provider  int             `json:"provider"`
-	S3Config  vfs.S3FsConfig  `json:"s3config,omitempty"`
+	// 0 local filesystem
+	Provider int `json:"provider"`
+	// 1 Amazon S3 compatible
+	S3Config vfs.S3FsConfig `json:"s3config,omitempty"`
+	// 2 Google Cloud Storage
 	GCSConfig vfs.GCSFsConfig `json:"gcsconfig,omitempty"`
+	// 3 Dynamic Configuration from URL
+	DynamicConfigurationURL vfs.DynFsConfigURL `json:"dynamic_configuration_url,omitempty"`
 }
 
 // User defines an SFTP user
@@ -122,6 +126,9 @@ type User struct {
 
 // GetFilesystem returns the filesystem for this user
 func (u *User) GetFilesystem(connectionID string) (vfs.Fs, error) {
+	if u.FsConfig.Provider == 2 {
+		return vfs.NewDynFs(connectionID, u.GetHomeDir(), u.FsConfig.DynamicConfigurationURL)
+	}
 	if u.FsConfig.Provider == 1 {
 		return vfs.NewS3Fs(connectionID, u.GetHomeDir(), u.FsConfig.S3Config)
 	} else if u.FsConfig.Provider == 2 {

--- a/go.mod
+++ b/go.mod
@@ -15,6 +15,7 @@ require (
 	github.com/golang/protobuf v1.3.3 // indirect
 	github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510
 	github.com/grandcat/zeroconf v1.0.0
+	github.com/hashicorp/go-retryablehttp v0.6.4
 	github.com/lib/pq v1.3.0
 	github.com/mattn/go-sqlite3 v2.0.3+incompatible
 	github.com/nathanaelle/password v1.0.0
@@ -34,7 +35,7 @@ require (
 	golang.org/x/exp v0.0.0-20200119233911-0405dc783f0a // indirect
 	golang.org/x/lint v0.0.0-20200130185559-910be7a94367 // indirect
 	golang.org/x/sys v0.0.0-20200124204421-9fbb57f87de9
-	golang.org/x/tools v0.0.0-20200131211209-ecb101ed6550 // indirect
+	golang.org/x/tools v0.0.0-20200131211209-ecb101ed6550
 	google.golang.org/api v0.15.0
 	google.golang.org/genproto v0.0.0-20200128133413-58ce757ed39b // indirect
 	google.golang.org/grpc v1.27.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -115,6 +115,11 @@ github.com/grandcat/zeroconf v1.0.0/go.mod h1:lTKmG1zh86XyCoUeIHSA4FJMBwCJiQmGfc
 github.com/grpc-ecosystem/go-grpc-middleware v1.0.0/go.mod h1:FiyG127CGDf3tlThmgyCl78X/SZQqEOJBCDaAfeWzPs=
 github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0/go.mod h1:8NvIoxWQoOIhqOTXgfV/d3M/q6VIi02HzZEHgUlZvzk=
 github.com/grpc-ecosystem/grpc-gateway v1.9.0/go.mod h1:vNeuVxBJEsws4ogUvrchl83t/GYV9WGTSLVdBhOQFDY=
+github.com/hashicorp/go-cleanhttp v0.5.1 h1:dH3aiDG9Jvb5r5+bYHsikaOUIpcM0xvgMXVoDkXMzJM=
+github.com/hashicorp/go-cleanhttp v0.5.1/go.mod h1:JpRdi6/HCYpAwUzNwuwqhbovhLtngrth3wmdIIUrZ80=
+github.com/hashicorp/go-hclog v0.9.2/go.mod h1:5CU+agLiy3J7N7QjHK5d05KxGsuXiQLrjA0H7acj2lQ=
+github.com/hashicorp/go-retryablehttp v0.6.4 h1:BbgctKO892xEyOXnGiaAwIoSq1QZ/SS4AhjoAh9DnfY=
+github.com/hashicorp/go-retryablehttp v0.6.4/go.mod h1:vAew36LZh98gCBJNLH42IQ1ER/9wtLZZ8meHqQvEYWY=
 github.com/hashicorp/golang-lru v0.5.0/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/hashicorp/golang-lru v0.5.1/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/hashicorp/hcl v1.0.0 h1:0Anlzjpi4vEasTeNFn2mLJgTSwt0+6sfsiTG8qcWGx4=
@@ -362,6 +367,7 @@ golang.org/x/tools v0.0.0-20191216173652-a0e659d51361/go.mod h1:TB2adYChydJhpapK
 golang.org/x/tools v0.0.0-20191227053925-7b8e75db28f4/go.mod h1:TB2adYChydJhpapKDTa4BR/hXlZSLoq2Wpct/0txZ28=
 golang.org/x/tools v0.0.0-20200117161641-43d50277825c/go.mod h1:TB2adYChydJhpapKDTa4BR/hXlZSLoq2Wpct/0txZ28=
 golang.org/x/tools v0.0.0-20200130002326-2f3ba24bd6e7/go.mod h1:TB2adYChydJhpapKDTa4BR/hXlZSLoq2Wpct/0txZ28=
+golang.org/x/tools v0.0.0-20200131211209-ecb101ed6550 h1:3Kc3/T5DQ/majKzDmb+0NzmbXFhKLaeDTp3KqVPV5Eo=
 golang.org/x/tools v0.0.0-20200131211209-ecb101ed6550/go.mod h1:TB2adYChydJhpapKDTa4BR/hXlZSLoq2Wpct/0txZ28=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=

--- a/templates/user.html
+++ b/templates/user.html
@@ -211,6 +211,7 @@
                 <option value="0" {{if eq .User.FsConfig.Provider 0 }}selected{{end}}>local</option>
                 <option value="1" {{if eq .User.FsConfig.Provider 1 }}selected{{end}}>Amazon S3 (Compatible)</option>
                 <option value="2" {{if eq .User.FsConfig.Provider 2 }}selected{{end}}>Google Cloud Storage</option>
+                <option value="3" {{if eq .User.FsConfig.Provider 3 }}selected{{end}}>Dynamic</option>
             </select>
         </div>
     </div>
@@ -312,6 +313,13 @@
         </div>
     </div>
 
+    <div class="form-group row dynfs">
+        <label for="idDynamicConfigurationURL" class="col-sm-2 col-form-label">Dynamic configuration source URL</label>
+        <div class="col-sm-10">
+            <input type="text" class="form-control" id="idDynamicConfigurationURL" name="dynamic_configuration_url" placeholder=""
+                value="{{.User.FsConfig.DynamicConfigurationURL}}" maxlength="255">
+        </div>
+    </div>
 
     <input type="hidden" name="expiration_date" id="hidden_start_datetime" value="">
     <button type="submit" class="btn btn-primary float-right mt-3 mb-5 px-5 px-3">Submit</button>
@@ -364,14 +372,22 @@
             $('.form-group.row.gcs').hide();
             $('.form-group.gcs').hide();
             $('.form-group.row.s3').show();
+            $('.form-group.row.dynfs').hide();
         } else if (val == '2'){
             $('.form-group.row.gcs').show();
             $('.form-group.gcs').show();
             $('.form-group.row.s3').hide();
+            $('.form-group.row.dynfs').hide();
+        } else if (val == '3'){
+            $('.form-group.row.gcs').hide();
+            $('.form-group.gcs').hide();
+            $('.form-group.row.s3').hide();
+            $('.form-group.row.dynfs').show();
         } else {
             $('.form-group.row.gcs').hide();
             $('.form-group.gcs').hide();
             $('.form-group.row.s3').hide();
+            $('.form-group.row.dynfs').hide();
         }
     }
 </script>

--- a/vfs/dynfs.go
+++ b/vfs/dynfs.go
@@ -1,0 +1,215 @@
+package vfs
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/eikenb/pipeat"
+	"github.com/hashicorp/go-retryablehttp"
+	"golang.org/x/tools/godoc/vfs"
+	"golang.org/x/tools/godoc/vfs/mapfs"
+)
+
+// DynFs is a Fs implementation that fetches a mapping from a remote URL and maps virtual dirs to real dirs
+type DynFs struct {
+	connectionID string
+	configURL    DynFsConfigURL
+	rootDir      string
+	VirtualFS    vfs.NameSpace
+}
+
+type DynFsConfigURL string
+
+func parseDynConfig(configURL DynFsConfigURL) (vfs.NameSpace, error) {
+	rawResponse := []byte{}
+	virtfs := vfs.NameSpace{}
+	var err error
+
+	if configURL == "" {
+		return virtfs, nil
+	}
+
+	resp, err := retryablehttp.Get(string(configURL))
+	if err != nil {
+		return virtfs, err
+	}
+	defer resp.Body.Close()
+
+	rawResponse, err = ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return virtfs, err
+	}
+
+	var response []string
+
+	err = json.Unmarshal(rawResponse, &response)
+	if err != nil {
+		return virtfs, err
+	}
+
+	mapResponseToVFS(response, &virtfs)
+
+	return virtfs, nil
+}
+
+func mapResponseToVFS(response []string, virtfs *vfs.NameSpace) {
+	for _, l := range response {
+		splitLine := strings.SplitN(l, ":", 3)
+		if len(splitLine) < 2 {
+			continue
+		}
+		virtLoc := splitLine[0]
+		realLoc := splitLine[1]
+
+		virtfs.Bind("/", mapfs.New(map[string]string{filepath.Join(virtLoc, ".hidden"): ""}), "/", vfs.BindAfter)
+		virtfs.Bind(filepath.Join("/", virtLoc), vfs.OS(realLoc), "/", vfs.BindAfter)
+	}
+}
+
+// NewDynFs returns an DynFs object that allows to interact with Dynamic filesystem
+func NewDynFs(connectionID, rootDir string, configURL DynFsConfigURL) (Fs, error) {
+	virtFS, err := parseDynConfig(configURL)
+	if err != nil {
+		return &DynFs{}, err
+	}
+
+	return &DynFs{
+		connectionID: connectionID,
+		rootDir:      rootDir,
+		configURL:    configURL,
+		VirtualFS:    virtFS,
+	}, nil
+}
+
+// Name returns the name for the Fs implementation
+func (fs DynFs) Name() string {
+	return fmt.Sprintf("DynFs from: %s", fs.configURL)
+}
+
+// ConnectionID returns the SSH connection ID associated to this Fs implementation
+func (fs DynFs) ConnectionID() string {
+	return fs.connectionID
+}
+
+// Stat returns a FileInfo describing the named file
+func (fs DynFs) Stat(name string) (os.FileInfo, error) {
+	return fs.VirtualFS.Stat(name)
+}
+
+// Lstat returns a FileInfo describing the named file
+func (fs DynFs) Lstat(name string) (os.FileInfo, error) {
+	return fs.VirtualFS.Lstat(name)
+}
+
+// Open opens the named file for reading
+func (fs DynFs) Open(name string) (*os.File, *pipeat.PipeReaderAt, func(), error) {
+	f, err := fs.VirtualFS.Open(name)
+
+	return f.(*os.File), nil, nil, err
+}
+
+// Create creates or opens the named file for writing
+func (fs DynFs) Create(name string, flag int) (*os.File, *pipeat.PipeWriterAt, func(), error) {
+	return nil, nil, nil, errors.New("operation not supported in virtual filesystem")
+}
+
+// Rename renames (moves) source to target
+func (fs DynFs) Rename(source, target string) error {
+	return errors.New("operation not supported in virtual filesystem")
+}
+
+// Remove removes the named file or (empty) directory.
+func (fs DynFs) Remove(name string, isDir bool) error {
+	return errors.New("operation not supported in virtual filesystem")
+}
+
+// Mkdir creates a new directory with the specified name and default permissions
+func (fs DynFs) Mkdir(name string) error {
+	return errors.New("operation not supported in virtual filesystem")
+}
+
+// Symlink creates source as a symbolic link to target.
+func (fs DynFs) Symlink(source, target string) error {
+	return errors.New("operation not supported in virtual filesystem")
+}
+
+// Chown changes the numeric uid and gid of the named file.
+func (fs DynFs) Chown(name string, uid int, gid int) error {
+	return errors.New("operation not supported in virtual filesystem")
+}
+
+// Chmod changes the mode of the named file to mode
+func (fs DynFs) Chmod(name string, mode os.FileMode) error {
+	return errors.New("operation not supported in virtual filesystem")
+}
+
+// Chtimes changes the access and modification times of the named file
+func (fs DynFs) Chtimes(name string, atime, mtime time.Time) error {
+	return errors.New("operation not supported in virtual filesystem")
+}
+
+// ReadDir reads the directory named by dirname and returns
+// a list of directory entries.
+func (fs DynFs) ReadDir(dirname string) ([]os.FileInfo, error) {
+	return fs.VirtualFS.ReadDir(dirname)
+}
+
+// IsUploadResumeSupported returns true if upload resume is supported
+func (fs DynFs) IsUploadResumeSupported() bool {
+	return false
+}
+
+// IsAtomicUploadSupported returns true if atomic upload is supported
+func (fs DynFs) IsAtomicUploadSupported() bool {
+	return false
+}
+
+// IsNotExist returns a boolean indicating whether the error is known to
+// report that a file or directory does not exist
+func (fs DynFs) IsNotExist(err error) bool {
+	return os.IsNotExist(err)
+}
+
+// IsPermission returns a boolean indicating whether the error is known to
+// report that permission is denied.
+func (fs DynFs) IsPermission(err error) bool {
+	return os.IsPermission(err)
+}
+
+// CheckRootPath creates the root directory if it does not exists
+func (fs DynFs) CheckRootPath(username string, uid int, gid int) bool {
+	return true
+}
+
+// ScanRootDirContents returns the number of files contained in a directory and
+// their size
+func (fs DynFs) ScanRootDirContents() (int, int64, error) {
+	return 0, 0, nil
+}
+
+// GetAtomicUploadPath returns the path to use for an atomic upload
+func (fs DynFs) GetAtomicUploadPath(name string) string {
+	return ""
+}
+
+// GetRelativePath returns the path for a file relative to the user's home dir.
+// This is the path as seen by SFTP users
+func (fs DynFs) GetRelativePath(name string) string {
+	return name
+}
+
+// Join joins any number of path elements into a single path
+func (fs DynFs) Join(elem ...string) string {
+	return filepath.Join(elem...)
+}
+
+// ResolvePath returns the matching filesystem path for the specified sftp path
+func (fs DynFs) ResolvePath(sftpPath string) (string, error) {
+	return sftpPath, nil
+}


### PR DESCRIPTION
This should be considered work-in-progress.

We have a special use case where users have access to a set of
locations, which varies over time (at a potentially fast pace).

As an example, a user "user1" can start services within our container
infrastructure. In the service definitions, (s)he will define a number
of volumes (in Docker notation), eg.:

```
--name service1-frontend
-v /nfs/volume/service1/data:/data
-v /nfs/volume/service1/config:/config
```

We have a microservice which parses these job definitions and will emit
a json array per user through a REST endpoint:

```
GET /volumes_for/user1
```

```json
[
  "/service1-frontend/data:/nfs/volume/service1/data:",
  "/service1-frontend/config:/nfs/volume/service1/config:"
]
```

With this code in `sftpgo`, I can configure a user "user1", select the
new Storage type "Dynamic", add <https://example.com/volumes_for/user1>
as the "Dynamic configuration source URL".

Then, when "user1" authenticates through sftp, (s)he will see the
following directory structure:

- `service1-frontend/`
  - `data/` -> contains data from `/nfs/volume/service1/data`
  - `config/` -> contains data from `/nfs/volume/service1/config`

(Obviously, this will add more services and folders within those
services, depending on the json response.)

This enables our "user1" to access the files which are inside the
container through SFTP, eg. to get log files, debug input files, etc.

For now, only browsing the directory structure and downloading files
works.

Signed-off-by: Jo Vandeginste <Jo.Vandeginste@kuleuven.be>