### PR TITLE
add verbose flag for portable mode

### DIFF
--- a/cmd/portable.go
+++ b/cmd/portable.go
@@ -24,6 +24,7 @@ var (
 	portableUsername             string
 	portablePassword             string
 	portableLogFile              string
+	portableLogVerbose           bool
 	portablePublicKeys           []string
 	portablePermissions          []string
 	portableSSHCommands          []string
@@ -90,7 +91,7 @@ Please take a look at the usage below to customize the serving parameters`,
 				LogMaxBackups: defaultLogMaxBackup,
 				LogMaxAge:     defaultLogMaxAge,
 				LogCompress:   defaultLogCompress,
-				LogVerbose:    defaultLogVerbose,
+				LogVerbose:    portableLogVerbose,
 				Profiler:      defaultProfiler,
 				Shutdown:      make(chan bool),
 				PortableMode:  1,
@@ -144,6 +145,7 @@ func init() {
 	portableCmd.Flags().StringVarP(&portableUsername, "username", "u", "", "Leave empty to use an auto generated value")
 	portableCmd.Flags().StringVarP(&portablePassword, "password", "p", "", "Leave empty to use an auto generated value")
 	portableCmd.Flags().StringVarP(&portableLogFile, logFilePathFlag, "l", "", "Leave empty to disable logging")
+	portableCmd.Flags().BoolVarP(&portableLogVerbose, logVerboseFlag, "v", false, "Enable verbose logs")
 	portableCmd.Flags().StringSliceVarP(&portablePublicKeys, "public-key", "k", []string{}, "")
 	portableCmd.Flags().StringSliceVarP(&portablePermissions, "permissions", "g", []string{"list", "download"},
 		"User's permissions. \"*\" means any permission")

--- a/docs/portable-mode.md
+++ b/docs/portable-mode.md
@@ -27,6 +27,7 @@ Flags:
       --gcs-storage-class string
   -h, --help                             help for portable
   -l, --log-file-path string             Leave empty to disable logging
+  -v, --log-verbose                      Enable verbose logs
   -p, --password string                  Leave empty to use an auto generated value
   -g, --permissions strings              User's permissions. "*" means any permission (default [list,download])
   -k, --public-key strings


### PR DESCRIPTION
I couldn't find a way to disable debug logs on portable mode.

I add a flag for it.