### PR TITLE
fix log level changing problem

### DIFF
--- a/logger/logger.go
+++ b/logger/logger.go
@@ -62,7 +62,7 @@ func InitLogger(logFilePath string, logMaxSize int, logMaxBackups int, logMaxAge
 			lock:   new(sync.Mutex)})
 		consoleLogger = zerolog.Nop()
 	}
-	logger.Level(level)
+	logger = logger.Level(level)
 }
 
 // DisableLogger disable the main logger.


### PR DESCRIPTION
`Level()` creates new logger. It's not changing current one. Receiver isn't a pointer.
So changing log level isn't effective.

```golang
// Level creates a child logger with the minimum accepted level set to level.
func (l Logger) Level(lvl Level) Logger {
	l.level = lvl
	return l
}
```