### PR TITLE
sftpd: set failed connection loglevel to debug

### DIFF
--- a/sftpd/server.go
+++ b/sftpd/server.go
@@ -270,7 +270,7 @@ func (c Configuration) AcceptInboundConnection(conn net.Conn, config *ssh.Server
 	}
 	sconn, chans, reqs, err := ssh.NewServerConn(conn, config)
 	if err != nil {
-		logger.Warn(logSender, "", "failed to accept an incoming connection: %v", err)
+		logger.Debug(logSender, "", "failed to accept an incoming connection: %v", err)
 		if _, ok := err.(*ssh.ServerAuthError); !ok {
 			logger.ConnectionFailedLog("", utils.GetIPFromRemoteAddress(remoteAddr.String()), "no_auth_tryed", err.Error())
 			metrics.AddNoAuthTryed()


### PR DESCRIPTION
"failed to accept an incoming connection" log level seems a little too high, it triggers on any TCP healthchecks on the sftp port (ex. healthcheck probes or network scan) 

Setting this as debug allows to stop logging these in non-verbose mode.