### PR TITLE
Set verbosity for go commands in docker build

### DIFF
--- a/docker/sftpgo/alpine/Dockerfile
+++ b/docker/sftpgo/alpine/Dockerfile
@@ -1,13 +1,13 @@
 FROM golang:alpine as builder
 
 RUN apk add --no-cache git gcc g++ ca-certificates \
-  && go get -d github.com/drakkan/sftpgo
+  && go get -v -d github.com/drakkan/sftpgo
 WORKDIR /go/src/github.com/drakkan/sftpgo
 ARG TAG
 ARG FEATURES
 # Use --build-arg TAG=LATEST for latest tag. Use e.g. --build-arg TAG=v1.0.0 for a specific tag/commit. Otherwise HEAD (master) is built.
 RUN git checkout $(if [ "${TAG}" = LATEST ]; then echo `git rev-list --tags --max-count=1`; elif [ -n "${TAG}" ]; then echo "${TAG}"; else echo HEAD; fi)
-RUN go build $(if [ -n "${FEATURES}" ]; then echo "-tags ${FEATURES}"; fi) -ldflags "-s -w -X github.com/drakkan/sftpgo/version.commit=`git describe --always --dirty` -X github.com/drakkan/sftpgo/version.date=`date -u +%FT%TZ`" -o /go/bin/sftpgo
+RUN go build $(if [ -n "${FEATURES}" ]; then echo "-tags ${FEATURES}"; fi) -ldflags "-s -w -X github.com/drakkan/sftpgo/version.commit=`git describe --always --dirty` -X github.com/drakkan/sftpgo/version.date=`date -u +%FT%TZ`" -v -o /go/bin/sftpgo
 
 FROM alpine:latest
 

--- a/docker/sftpgo/debian/Dockerfile
+++ b/docker/sftpgo/debian/Dockerfile
@@ -1,13 +1,13 @@
 # we use a multi stage build to have a separate build and run env
 FROM golang:latest as buildenv
 LABEL maintainer="nicola.murino@gmail.com"
-RUN go get -d github.com/drakkan/sftpgo
+RUN go get -v -d github.com/drakkan/sftpgo
 WORKDIR /go/src/github.com/drakkan/sftpgo
 ARG TAG
 ARG FEATURES
 # Use --build-arg TAG=LATEST for latest tag. Use e.g. --build-arg TAG=v1.0.0 for a specific tag/commit. Otherwise HEAD (master) is built.
 RUN git checkout $(if [ "${TAG}" = LATEST ]; then echo `git rev-list --tags --max-count=1`; elif [ -n "${TAG}" ]; then echo "${TAG}"; else echo HEAD; fi)
-RUN go build $(if [ -n "${FEATURES}" ]; then echo "-tags ${FEATURES}"; fi) -ldflags "-s -w -X github.com/drakkan/sftpgo/version.commit=`git describe --always --dirty` -X github.com/drakkan/sftpgo/version.date=`date -u +%FT%TZ`" -o sftpgo
+RUN go build $(if [ -n "${FEATURES}" ]; then echo "-tags ${FEATURES}"; fi) -ldflags "-s -w -X github.com/drakkan/sftpgo/version.commit=`git describe --always --dirty` -X github.com/drakkan/sftpgo/version.date=`date -u +%FT%TZ`" -v -o sftpgo
 
 # now define the run environment
 FROM debian:latest


### PR DESCRIPTION
To visualize the progress of the docker builds, I added the `-v` flags to the go commands.