### PR TITLE
GCS: improve mime-type detection

### DIFF
--- a/vfs/gcsfs.go
+++ b/vfs/gcsfs.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"mime"
 	"net/http"
 	"os"
 	"path"
@@ -181,6 +182,10 @@ func (fs GCSFs) Create(name string, flag int) (*os.File, *PipeWriter, func(), er
 	obj := bkt.Object(name)
 	ctx, cancelFn := context.WithCancel(context.Background())
 	objectWriter := obj.NewWriter(ctx)
+	contentType := mime.TypeByExtension(path.Ext(name))
+	if contentType != "" {
+	    objectWriter.ObjectAttrs.ContentType = contentType
+	}
 	if len(fs.config.StorageClass) > 0 {
 		objectWriter.ObjectAttrs.StorageClass = fs.config.StorageClass
 	}


### PR DESCRIPTION
As suggested by @drakkan in #178, better mime type detection than used in the [google-cloud-go](https://github.com/googleapis/google-cloud-go/blob/master/storage/storage.go#L1004) underlying package.

Example which previously gave `application/zip` as mime type:
![image](https://user-images.githubusercontent.com/66438062/94471823-13ac1b80-01ca-11eb-882b-8645e55e99db.png)
