### PR TITLE
Add ability to conditionally set default data_provider.name

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -154,6 +154,7 @@ jobs:
             org.opencontainers.image.licenses=${{ fromJson(steps.repo.outputs.result).license.spdx_id }}
 
       - name: Build and push full
+        if: ${{ github.event_name != 'pull_request' }}
         uses: docker/build-push-action@v2
         with:
           builder: ${{ steps.builder-full.outputs.name }}

--- a/cmd/startsubsys.go
+++ b/cmd/startsubsys.go
@@ -72,7 +72,7 @@ Command-line flags should be specified in the Subsystem declaration.
 				logger.Debug(logSender, connectionID, "data provider %#v not supported in subsystem mode, using %#v provider",
 					dataProviderConf.Driver, dataprovider.MemoryDataProviderName)
 				dataProviderConf.Driver = dataprovider.MemoryDataProviderName
-				dataProviderConf.Name = ""
+				dataProviderConf.Name = new(string)
 				dataProviderConf.PreferDatabaseCredentials = true
 			}
 			config.SetProviderConf(dataProviderConf)

--- a/common/common_test.go
+++ b/common/common_test.go
@@ -166,9 +166,14 @@ func initializeDataprovider(trackQuota int) (string, error) {
 	if err := viper.ReadInConfig(); err != nil {
 		return "", err
 	}
+	// @TODO Why doesn't this use the config loader? It bypasses setting conditional defaults
 	var cfg providerConf
 	if err := viper.Unmarshal(&cfg); err != nil {
 		return "", err
+	}
+	if cfg.Config.Name == nil {
+		name := "sftpgo.db"
+		cfg.Config.Name = &name
 	}
 	if trackQuota >= 0 && trackQuota <= 2 {
 		cfg.Config.TrackQuota = trackQuota

--- a/dataprovider/bolt.go
+++ b/dataprovider/bolt.go
@@ -42,7 +42,7 @@ func init() {
 func initializeBoltProvider(basePath string) error {
 	var err error
 	logSender = fmt.Sprintf("dataprovider_%v", BoltDataProviderName)
-	dbPath := config.Name
+	dbPath := *config.Name
 	if !utils.IsFileInputValid(dbPath) {
 		return fmt.Errorf("Invalid database path: %#v", dbPath)
 	}

--- a/dataprovider/dataprovider.go
+++ b/dataprovider/dataprovider.go
@@ -156,7 +156,7 @@ type Config struct {
 	Driver string `json:"driver" mapstructure:"driver"`
 	// Database name. For driver sqlite this can be the database name relative to the config dir
 	// or the absolute path to the SQLite database.
-	Name string `json:"name" mapstructure:"name"`
+	Name *string `json:"name" mapstructure:"name"`
 	// Database host
 	Host string `json:"host" mapstructure:"host"`
 	// Database port

--- a/dataprovider/memory.go
+++ b/dataprovider/memory.go
@@ -44,8 +44,8 @@ type MemoryProvider struct {
 func initializeMemoryProvider(basePath string) error {
 	logSender = fmt.Sprintf("dataprovider_%v", MemoryDataProviderName)
 	configFile := ""
-	if utils.IsFileInputValid(config.Name) {
-		configFile = config.Name
+	if utils.IsFileInputValid(*config.Name) {
+		configFile = *config.Name
 		if !filepath.IsAbs(configFile) {
 			configFile = filepath.Join(basePath, configFile)
 		}

--- a/dataprovider/mysql.go
+++ b/dataprovider/mysql.go
@@ -73,7 +73,7 @@ func getMySQLConnectionString(redactedPwd bool) string {
 			password = "[redacted]"
 		}
 		connectionString = fmt.Sprintf("%v:%v@tcp([%v]:%v)/%v?charset=utf8&interpolateParams=true&timeout=10s&tls=%v&writeTimeout=10s&readTimeout=10s",
-			config.Username, password, config.Host, config.Port, config.Name, getSSLMode())
+			config.Username, password, config.Host, config.Port, *config.Name, getSSLMode())
 	} else {
 		connectionString = config.ConnectionString
 	}

--- a/dataprovider/pgsql.go
+++ b/dataprovider/pgsql.go
@@ -72,7 +72,7 @@ func getPGSQLConnectionString(redactedPwd bool) string {
 			password = "[redacted]"
 		}
 		connectionString = fmt.Sprintf("host='%v' port=%v dbname='%v' user='%v' password='%v' sslmode=%v connect_timeout=10",
-			config.Host, config.Port, config.Name, config.Username, password, getSSLMode())
+			config.Host, config.Port, *config.Name, config.Username, password, getSSLMode())
 	} else {
 		connectionString = config.ConnectionString
 	}

--- a/dataprovider/sqlite.go
+++ b/dataprovider/sqlite.go
@@ -79,7 +79,7 @@ func initializeSQLiteProvider(basePath string) error {
 	var connectionString string
 	logSender = fmt.Sprintf("dataprovider_%v", SQLiteDataProviderName)
 	if len(config.ConnectionString) == 0 {
-		dbPath := config.Name
+		dbPath := *config.Name
 		if !utils.IsFileInputValid(dbPath) {
 			return fmt.Errorf("Invalid database path: %#v", dbPath)
 		}

--- a/service/service_portable.go
+++ b/service/service_portable.go
@@ -35,7 +35,7 @@ func (s *Service) StartPortableMode(sftpdPort, ftpPort, webdavPort int, enabledS
 	printablePassword := s.configurePortableUser()
 	dataProviderConf := config.GetProviderConf()
 	dataProviderConf.Driver = dataprovider.MemoryDataProviderName
-	dataProviderConf.Name = ""
+	dataProviderConf.Name = new(string)
 	dataProviderConf.PreferDatabaseCredentials = true
 	config.SetProviderConf(dataProviderConf)
 	httpdConf := config.GetHTTPDConfig()

--- a/sftpgo.json
+++ b/sftpgo.json
@@ -74,7 +74,7 @@
   },
   "data_provider": {
     "driver": "sqlite",
-    "name": "sftpgo.db",
+    "name": null,
     "host": "",
     "port": 5432,
     "username": "",


### PR DESCRIPTION
To fix an issue reported in #229.

We now have `config.setConditionalDefaults()` called after the configuration file is parsed. This allows us to change default configurations based on any criteria desired.

Currently it is being used to set `data_provider.name` to `""` by default if using the `memory` driver.

This is only a default and can be overridden by any available configuration methods.