### PR TITLE
S3fs: Handle non-ascii filename in rename operations

### DIFF
--- a/vfs/s3fs.go
+++ b/vfs/s3fs.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"mime"
+	"net/url"
 	"os"
 	"path"
 	"path/filepath"
@@ -297,7 +298,7 @@ func (fs *S3Fs) Rename(source, target string) error {
 	defer cancelFn()
 	_, err = fs.svc.CopyObjectWithContext(ctx, &s3.CopyObjectInput{
 		Bucket:       aws.String(fs.config.Bucket),
-		CopySource:   aws.String(copySource),
+		CopySource:   aws.String(url.PathEscape(copySource)),
 		Key:          aws.String(target),
 		StorageClass: utils.NilIfEmpty(fs.config.StorageClass),
 		ContentType:  utils.NilIfEmpty(contentType),


### PR DESCRIPTION
SFTP is based on UTF-8 filenames, so non-ASCII filenames get transported with utf-8 escaped character sequences.
At least for the S3fs provider, if such a file is stored in a nested path it cannot be used as the source for a rename operations.

This adds the necessary escaping of the path fragments.


@drakkan I'm not sure how testing is done (assuming it's manual as per the README). I created this one as the result of bug report and verified the change to be working against an AWS S3 bucket using german umlauts (eg `äöü`). Pls advise if there is something else that should be done for verification from my side.