### PR TITLE
S3fs: don't paginate to find zero-byte-keyed dirs

### DIFF
--- a/vfs/s3fs.go
+++ b/vfs/s3fs.go
@@ -139,7 +139,10 @@ func (fs *S3Fs) Stat(name string) (os.FileInfo, error) {
 	// with a forwarding slash.
 	obj, err = fs.headObject(strings.TrimPrefix(name, "/") + "/")
 	if err == nil {
-		return NewFileInfo(name, true, 0, time.Now(), false), nil
+		objSize := *obj.ContentLength
+		objectModTime := *obj.LastModified
+		isDir := *obj.ContentType == dirMimeType
+		return NewFileInfo(name, isDir, objSize, objectModTime, false), nil
 	}
 	if !fs.IsNotExist(err) {
 		return result, err
@@ -584,19 +587,6 @@ func (fs *S3Fs) resolve(name *string, prefix string) (string, bool) {
 		result = result[:i]
 	}
 	return result, isDir
-}
-
-func (fs *S3Fs) isEqual(s3Key *string, virtualName string) bool {
-	if *s3Key == virtualName {
-		return true
-	}
-	if "/"+*s3Key == virtualName {
-		return true
-	}
-	if "/"+*s3Key == virtualName+"/" {
-		return true
-	}
-	return false
 }
 
 func (fs *S3Fs) checkIfBucketExists() error {

--- a/vfs/s3fs.go
+++ b/vfs/s3fs.go
@@ -4,7 +4,6 @@ package vfs
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"mime"
 	"net/url"
@@ -142,7 +141,7 @@ func (fs *S3Fs) Stat(name string) (os.FileInfo, error) {
 	if err == nil {
 		return NewFileInfo(name, true, 0, time.Now(), false), nil
 	}
-	if !fs.IsNotExists(err) {
+	if !fs.IsNotExist(err) {
 		return result, err
 	}
 	return nil, err

--- a/vfs/s3fs.go
+++ b/vfs/s3fs.go
@@ -123,7 +123,8 @@ func (fs *S3Fs) Stat(name string) (os.FileInfo, error) {
 	if err == nil {
 		objSize := *obj.ContentLength
 		objectModTime := *obj.LastModified
-		return NewFileInfo(name, false, objSize, objectModTime, false), nil
+		isDir := *obj.ContentType == dirMimeType
+		return NewFileInfo(name, isDir, objSize, objectModTime, false), nil
 	}
 	if !fs.IsNotExist(err) {
 		return result, err
@@ -141,8 +142,7 @@ func (fs *S3Fs) Stat(name string) (os.FileInfo, error) {
 	if err == nil {
 		objSize := *obj.ContentLength
 		objectModTime := *obj.LastModified
-		isDir := *obj.ContentType == dirMimeType
-		return NewFileInfo(name, isDir, objSize, objectModTime, false), nil
+		return NewFileInfo(name, true, objSize, objectModTime, false), nil
 	}
 	if !fs.IsNotExist(err) {
 		return result, err


### PR DESCRIPTION
This PR removes `getStatCompat()` and uses `HEAD <name>/` to stat "directories"; see #275