### PR TITLE
vfs: introduced string Provider IDs

### DIFF
--- a/cmd/portable.go
+++ b/cmd/portable.go
@@ -34,7 +34,7 @@ var (
 	portableSSHCommands                []string
 	portableAllowedPatterns            []string
 	portableDeniedPatterns             []string
-	portableFsProvider                 int
+	portableFsProvider                 string
 	portableS3Bucket                   string
 	portableS3Region                   string
 	portableS3AccessKey                string
@@ -85,7 +85,7 @@ $ sftpgo portable
 Please take a look at the usage below to customize the serving parameters`,
 		Run: func(cmd *cobra.Command, args []string) {
 			portableDir := directoryToServe
-			fsProvider := vfs.FilesystemProvider(portableFsProvider)
+			fsProvider := vfs.GetProviderByName(portableFsProvider)
 			if !filepath.IsAbs(portableDir) {
 				if fsProvider == vfs.LocalFilesystemProvider {
 					portableDir, _ = filepath.Abs(portableDir)
@@ -151,7 +151,7 @@ Please take a look at the usage below to customize the serving parameters`,
 					HomeDir:     portableDir,
 					Status:      1,
 					FsConfig: vfs.Filesystem{
-						Provider: vfs.FilesystemProvider(portableFsProvider),
+						Provider: vfs.GetProviderByName(portableFsProvider),
 						S3Config: vfs.S3FsConfig{
 							Bucket:            portableS3Bucket,
 							Region:            portableS3Region,
@@ -259,12 +259,12 @@ multicast DNS`)
 advertised via multicast DNS, this
 flag allows to put username/password
 inside the advertised TXT record`)
-	portableCmd.Flags().IntVarP(&portableFsProvider, "fs-provider", "f", int(vfs.LocalFilesystemProvider), `0 => local filesystem
-1 => AWS S3 compatible
-2 => Google Cloud Storage
-3 => Azure Blob Storage
-4 => Encrypted local filesystem
-5 => SFTP`)
+	portableCmd.Flags().StringVarP(&portableFsProvider, "fs-provider", "f", "osfs", `osfs => local filesystem (legacy value: 0)
+s3fs => AWS S3 compatible (legacy: 1)
+gcsfs => Google Cloud Storage (legacy: 2)
+azblobfs => Azure Blob Storage (legacy: 3)
+cryptfs => Encrypted local filesystem (legacy: 4)
+sftpfs => SFTP (legacy: 5)`)
 	portableCmd.Flags().StringVar(&portableS3Bucket, "s3-bucket", "", "")
 	portableCmd.Flags().StringVar(&portableS3Region, "s3-region", "", "")
 	portableCmd.Flags().StringVar(&portableS3AccessKey, "s3-access-key", "", "")

--- a/dataprovider/user.go
+++ b/dataprovider/user.go
@@ -1005,17 +1005,8 @@ func (u *User) GetInfoString() string {
 		t := utils.GetTimeFromMsecSinceEpoch(u.LastLogin)
 		result += fmt.Sprintf("Last login: %v ", t.Format("2006-01-02 15:04")) // YYYY-MM-DD HH:MM
 	}
-	switch u.FsConfig.Provider {
-	case vfs.S3FilesystemProvider:
-		result += "Storage: S3 "
-	case vfs.GCSFilesystemProvider:
-		result += "Storage: GCS "
-	case vfs.AzureBlobFilesystemProvider:
-		result += "Storage: AzBlob "
-	case vfs.CryptedFilesystemProvider:
-		result += "Storage: Encrypted "
-	case vfs.SFTPFilesystemProvider:
-		result += "Storage: SFTP "
+	if u.FsConfig.Provider != vfs.LocalFilesystemProvider {
+		result += fmt.Sprintf("Storage: %s ", u.FsConfig.Provider.ShortInfo())
 	}
 	if len(u.PublicKeys) > 0 {
 		result += fmt.Sprintf("Public keys: %v ", len(u.PublicKeys))

--- a/httpd/webadmin.go
+++ b/httpd/webadmin.go
@@ -252,20 +252,23 @@ func loadAdminTemplates(templatesPath string) {
 		filepath.Join(templatesPath, templateAdminDir, templateSetup),
 	}
 
-	usersTmpl := utils.LoadTemplate(nil, usersPaths...)
-	userTmpl := utils.LoadTemplate(nil, userPaths...)
-	adminsTmpl := utils.LoadTemplate(nil, adminsPaths...)
-	adminTmpl := utils.LoadTemplate(nil, adminPaths...)
-	connectionsTmpl := utils.LoadTemplate(nil, connectionsPaths...)
-	messageTmpl := utils.LoadTemplate(nil, messagePath...)
-	foldersTmpl := utils.LoadTemplate(nil, foldersPath...)
-	folderTmpl := utils.LoadTemplate(nil, folderPath...)
-	statusTmpl := utils.LoadTemplate(nil, statusPath...)
-	loginTmpl := utils.LoadTemplate(nil, loginPath...)
-	changePwdTmpl := utils.LoadTemplate(nil, changePwdPaths...)
-	maintenanceTmpl := utils.LoadTemplate(nil, maintenancePath...)
-	defenderTmpl := utils.LoadTemplate(nil, defenderPath...)
-	setupTmpl := utils.LoadTemplate(nil, setupPath...)
+	rootTpl := template.New("").Funcs(template.FuncMap{
+		"ListFSProviders": vfs.ListProviders,
+	})
+	usersTmpl := utils.LoadTemplate(rootTpl, usersPaths...)
+	userTmpl := utils.LoadTemplate(rootTpl, userPaths...)
+	adminsTmpl := utils.LoadTemplate(rootTpl, adminsPaths...)
+	adminTmpl := utils.LoadTemplate(rootTpl, adminPaths...)
+	connectionsTmpl := utils.LoadTemplate(rootTpl, connectionsPaths...)
+	messageTmpl := utils.LoadTemplate(rootTpl, messagePath...)
+	foldersTmpl := utils.LoadTemplate(rootTpl, foldersPath...)
+	folderTmpl := utils.LoadTemplate(rootTpl, folderPath...)
+	statusTmpl := utils.LoadTemplate(rootTpl, statusPath...)
+	loginTmpl := utils.LoadTemplate(rootTpl, loginPath...)
+	changePwdTmpl := utils.LoadTemplate(rootTpl, changePwdPaths...)
+	maintenanceTmpl := utils.LoadTemplate(rootTpl, maintenancePath...)
+	defenderTmpl := utils.LoadTemplate(rootTpl, defenderPath...)
+	setupTmpl := utils.LoadTemplate(rootTpl, setupPath...)
 
 	adminTemplates[templateUsers] = usersTmpl
 	adminTemplates[templateUser] = userTmpl

--- a/httpd/webadmin.go
+++ b/httpd/webadmin.go
@@ -754,11 +754,7 @@ func getAzureConfig(r *http.Request) (vfs.AzBlobFsConfig, error) {
 
 func getFsConfigFromPostFields(r *http.Request) (vfs.Filesystem, error) {
 	var fs vfs.Filesystem
-	provider, err := strconv.Atoi(r.Form.Get("fs_provider"))
-	if err != nil {
-		provider = int(vfs.LocalFilesystemProvider)
-	}
-	fs.Provider = vfs.FilesystemProvider(provider)
+	fs.Provider = vfs.GetProviderByName(r.Form.Get("fs_provider"))
 	switch fs.Provider {
 	case vfs.S3FilesystemProvider:
 		config, err := getS3Config(r)

--- a/httpd/webadmin.go
+++ b/httpd/webadmin.go
@@ -251,20 +251,21 @@ func loadAdminTemplates(templatesPath string) {
 	setupPath := []string{
 		filepath.Join(templatesPath, templateAdminDir, templateSetup),
 	}
-	usersTmpl := utils.LoadTemplate(template.ParseFiles(usersPaths...))
-	userTmpl := utils.LoadTemplate(template.ParseFiles(userPaths...))
-	adminsTmpl := utils.LoadTemplate(template.ParseFiles(adminsPaths...))
-	adminTmpl := utils.LoadTemplate(template.ParseFiles(adminPaths...))
-	connectionsTmpl := utils.LoadTemplate(template.ParseFiles(connectionsPaths...))
-	messageTmpl := utils.LoadTemplate(template.ParseFiles(messagePath...))
-	foldersTmpl := utils.LoadTemplate(template.ParseFiles(foldersPath...))
-	folderTmpl := utils.LoadTemplate(template.ParseFiles(folderPath...))
-	statusTmpl := utils.LoadTemplate(template.ParseFiles(statusPath...))
-	loginTmpl := utils.LoadTemplate(template.ParseFiles(loginPath...))
-	changePwdTmpl := utils.LoadTemplate(template.ParseFiles(changePwdPaths...))
-	maintenanceTmpl := utils.LoadTemplate(template.ParseFiles(maintenancePath...))
-	defenderTmpl := utils.LoadTemplate(template.ParseFiles(defenderPath...))
-	setupTmpl := utils.LoadTemplate(template.ParseFiles(setupPath...))
+
+	usersTmpl := utils.LoadTemplate(nil, usersPaths...)
+	userTmpl := utils.LoadTemplate(nil, userPaths...)
+	adminsTmpl := utils.LoadTemplate(nil, adminsPaths...)
+	adminTmpl := utils.LoadTemplate(nil, adminPaths...)
+	connectionsTmpl := utils.LoadTemplate(nil, connectionsPaths...)
+	messageTmpl := utils.LoadTemplate(nil, messagePath...)
+	foldersTmpl := utils.LoadTemplate(nil, foldersPath...)
+	folderTmpl := utils.LoadTemplate(nil, folderPath...)
+	statusTmpl := utils.LoadTemplate(nil, statusPath...)
+	loginTmpl := utils.LoadTemplate(nil, loginPath...)
+	changePwdTmpl := utils.LoadTemplate(nil, changePwdPaths...)
+	maintenanceTmpl := utils.LoadTemplate(nil, maintenancePath...)
+	defenderTmpl := utils.LoadTemplate(nil, defenderPath...)
+	setupTmpl := utils.LoadTemplate(nil, setupPath...)
 
 	adminTemplates[templateUsers] = usersTmpl
 	adminTemplates[templateUser] = userTmpl

--- a/httpd/webclient.go
+++ b/httpd/webclient.go
@@ -123,10 +123,10 @@ func loadClientTemplates(templatesPath string) {
 		filepath.Join(templatesPath, templateClientDir, templateClientMessage),
 	}
 
-	filesTmpl := utils.LoadTemplate(template.ParseFiles(filesPaths...))
-	credentialsTmpl := utils.LoadTemplate(template.ParseFiles(credentialsPaths...))
-	loginTmpl := utils.LoadTemplate(template.ParseFiles(loginPath...))
-	messageTmpl := utils.LoadTemplate(template.ParseFiles(messagePath...))
+	filesTmpl := utils.LoadTemplate(nil, filesPaths...)
+	credentialsTmpl := utils.LoadTemplate(nil, credentialsPaths...)
+	loginTmpl := utils.LoadTemplate(nil, loginPath...)
+	messageTmpl := utils.LoadTemplate(nil, messagePath...)
 
 	clientTemplates[templateClientFiles] = filesTmpl
 	clientTemplates[templateClientCredentials] = credentialsTmpl

--- a/templates/webadmin/folder.html
+++ b/templates/webadmin/folder.html
@@ -99,7 +99,7 @@
 {{define "extra_js"}}
 <script type="text/javascript">
     $(document).ready(function () {
-        onFilesystemChanged('{{.Folder.FsConfig.Provider}}');
+        onFilesystemChanged('{{.Folder.FsConfig.Provider.Name}}');
 
         $("body").on("click", ".add_new_tpl_folder_field_btn", function () {
             var index = $(".form_field_tpl_folders_outer").find(".form_field_tpl_folder_outer_row").length;

--- a/templates/webadmin/fsconfig.html
+++ b/templates/webadmin/fsconfig.html
@@ -13,7 +13,7 @@
             </div>
         </div>
 
-        <div class="form-group row s3">
+        <div class="form-group row fsconfig fsconfig-s3fs">
             <label for="idS3Bucket" class="col-sm-2 col-form-label">Bucket</label>
             <div class="col-sm-3">
                 <input type="text" class="form-control" id="idS3Bucket" name="s3_bucket" placeholder=""
@@ -27,7 +27,7 @@
             </div>
         </div>
 
-        <div class="form-group row s3">
+        <div class="form-group row fsconfig fsconfig-s3fs">
             <label for="idS3AccessKey" class="col-sm-2 col-form-label">Access Key</label>
             <div class="col-sm-3">
                 <input type="text" class="form-control" id="idS3AccessKey" name="s3_access_key" placeholder=""
@@ -42,7 +42,7 @@
             </div>
         </div>
 
-        <div class="form-group row s3">
+        <div class="form-group row fsconfig fsconfig-s3fs">
             <label for="idS3StorageClass" class="col-sm-2 col-form-label">Storage Class</label>
             <div class="col-sm-3">
                 <input type="text" class="form-control" id="idS3StorageClass" name="s3_storage_class" placeholder=""
@@ -56,7 +56,7 @@
             </div>
         </div>
 
-        <div class="form-group row s3">
+        <div class="form-group row fsconfig fsconfig-s3fs">
             <label for="idS3PartSize" class="col-sm-2 col-form-label">UL Part Size (MB)</label>
             <div class="col-sm-3">
                 <input type="number" class="form-control" id="idS3PartSize" name="s3_upload_part_size" placeholder=""
@@ -77,7 +77,7 @@
             </div>
         </div>
 
-        <div class="form-group row s3">
+        <div class="form-group row fsconfig fsconfig-s3fs">
             <label for="idS3KeyPrefix" class="col-sm-2 col-form-label">Key Prefix</label>
             <div class="col-sm-10">
                 <input type="text" class="form-control" id="idS3KeyPrefix" name="s3_key_prefix" placeholder=""
@@ -88,7 +88,7 @@
             </div>
         </div>
 
-        <div class="form-group row gcs">
+        <div class="form-group row fsconfig fsconfig-gcsfs">
             <label for="idGCSBucket" class="col-sm-2 col-form-label">Bucket</label>
             <div class="col-sm-10">
                 <input type="text" class="form-control" id="idGCSBucket" name="gcs_bucket" placeholder=""
@@ -96,7 +96,7 @@
             </div>
         </div>
 
-        <div class="form-group row gcs">
+        <div class="form-group row fsconfig fsconfig-gcsfs">
             <label for="idGCSCredentialFile" class="col-sm-2 col-form-label">Credentials file</label>
             <div class="col-sm-4">
                 <input type="file" class="form-control-file" id="idGCSCredentialFile" name="gcs_credential_file"
@@ -113,7 +113,7 @@
             </div>
         </div>
 
-        <div class="form-group gcs">
+        <div class="form-group fsconfig fsconfig-gcsfs">
             <div class="form-check">
                 <input type="checkbox" class="form-check-input" id="idGCSAutoCredentials" name="gcs_auto_credentials"
                     {{if gt .GCSConfig.AutomaticCredentials 0}}checked{{end}}>
@@ -121,7 +121,7 @@
             </div>
         </div>
 
-        <div class="form-group row gcs">
+        <div class="form-group row fsconfig fsconfig-gcsfs">
             <label for="idGCSKeyPrefix" class="col-sm-2 col-form-label">Key Prefix</label>
             <div class="col-sm-10">
                 <input type="text" class="form-control" id="idGCSKeyPrefix" name="gcs_key_prefix" placeholder=""
@@ -132,7 +132,7 @@
             </div>
         </div>
 
-        <div class="form-group row azblob">
+        <div class="form-group row fsconfig fsconfig-azblobfs">
             <label for="idAzContainer" class="col-sm-2 col-form-label">Container</label>
             <div class="col-sm-3">
                 <input type="text" class="form-control" id="idAzContainer" name="az_container" placeholder=""
@@ -146,7 +146,7 @@
             </div>
         </div>
 
-        <div class="form-group row azblob">
+        <div class="form-group row fsconfig fsconfig-azblobfs">
             <label for="idAzAccountKey" class="col-sm-2 col-form-label">Account Key</label>
             <div class="col-sm-10">
                 <input type="password" class="form-control" id="idAzAccountKey" name="az_account_key" placeholder=""
@@ -155,14 +155,14 @@
             </div>
         </div>
 
-        <div class="form-group row azblob">
+        <div class="form-group row fsconfig fsconfig-azblobfs">
             <label for="idAzSASURL" class="col-sm-2 col-form-label">SAS URL</label>
             <div class="col-sm-10">
                 <input type="password" class="form-control" id="idAzSASURL" name="az_sas_url" placeholder=""
                     value="{{if .AzBlobConfig.SASURL.IsEncrypted}}{{.RedactedSecret}}{{else}}{{.AzBlobConfig.SASURL.GetPayload}}{{end}}" maxlength="1000">
             </div>
         </div>
-        <div class="form-group row azblob">
+        <div class="form-group row fsconfig fsconfig-azblobfs">
             <label for="idAzEndpoint" class="col-sm-2 col-form-label">Endpoint</label>
             <div class="col-sm-10">
                 <input type="text" class="form-control" id="idAzEndpoint" name="az_endpoint" placeholder=""
@@ -170,7 +170,7 @@
             </div>
         </div>
 
-        <div class="form-group row azblob">
+        <div class="form-group row fsconfig fsconfig-azblobfs">
             <label for="idAzAccessTier" class="col-sm-2 col-form-label">Access Tier</label>
             <div class="col-sm-10">
                 <select class="form-control" id="idAzAccessTier" name="az_access_tier">
@@ -183,7 +183,7 @@
             </div>
         </div>
 
-        <div class="form-group row azblob">
+        <div class="form-group row fsconfig fsconfig-azblobfs">
             <label for="idAzPartSize" class="col-sm-2 col-form-label">UL Part Size (MB)</label>
             <div class="col-sm-3">
                 <input type="number" class="form-control" id="idAzPartSize" name="az_upload_part_size" placeholder=""
@@ -204,7 +204,7 @@
             </div>
         </div>
 
-        <div class="form-group row azblob">
+        <div class="form-group row fsconfig fsconfig-azblobfs">
             <label for="idAzKeyPrefix" class="col-sm-2 col-form-label">Key Prefix</label>
             <div class="col-sm-10">
                 <input type="text" class="form-control" id="idAzKeyPrefix" name="az_key_prefix" placeholder=""
@@ -215,7 +215,7 @@
             </div>
         </div>
 
-        <div class="form-group azblob">
+        <div class="form-group fsconfig fsconfig-azblobfs">
             <div class="form-check">
                 <input type="checkbox" class="form-check-input" id="idUseEmulator" name="az_use_emulator" {{if
                     .AzBlobConfig.UseEmulator}}checked{{end}}>
@@ -223,7 +223,7 @@
             </div>
         </div>
 
-        <div class="form-group row crypt">
+        <div class="form-group row fsconfig fsconfig-cryptfs">
             <label for="idCryptPassphrase" class="col-sm-2 col-form-label">Passphrase</label>
             <div class="col-sm-10">
                 <input type="password" class="form-control" id="idCryptPassphrase" name="crypt_passphrase"
@@ -233,7 +233,7 @@
             </div>
         </div>
 
-        <div class="form-group row sftp">
+        <div class="form-group row fsconfig fsconfig-sftpfs">
             <label for="idSFTPEndpoint" class="col-sm-2 col-form-label">Endpoint</label>
             <div class="col-sm-3">
                 <input type="text" class="form-control" id="idSFTPEndpoint" name="sftp_endpoint" placeholder=""
@@ -253,7 +253,7 @@
             </div>
         </div>
 
-        <div class="form-group row sftp">
+        <div class="form-group row fsconfig fsconfig-sftpfs">
             <label for="idSFTPUsername" class="col-sm-2 col-form-label">Username</label>
             <div class="col-sm-3">
                 <input type="text" class="form-control" id="idSFTPUsername" name="sftp_username" placeholder=""
@@ -268,7 +268,7 @@
             </div>
         </div>
 
-        <div class="form-group row sftp">
+        <div class="form-group row fsconfig fsconfig-sftpfs">
             <label for="idSFTPPrivateKey" class="col-sm-2 col-form-label">Private key</label>
             <div class="col-sm-10">
                 <textarea type="password" class="form-control" id="idSFTPPrivateKey" name="sftp_private_key"
@@ -276,7 +276,7 @@
             </div>
         </div>
 
-        <div class="form-group row sftp">
+        <div class="form-group row fsconfig fsconfig-sftpfs">
             <label for="idSFTPFingerprints" class="col-sm-2 col-form-label">Fingerprints</label>
             <div class="col-sm-10">
                 <textarea class="form-control" id="idSFTPFingerprints" name="sftp_fingerprints" rows="3"
@@ -288,7 +288,7 @@
             </div>
         </div>
 
-        <div class="form-group row sftp">
+        <div class="form-group row fsconfig fsconfig-sftpfs">
             <label for="idSFTPPrefix" class="col-sm-2 col-form-label">Prefix</label>
             <div class="col-sm-10">
                 <input type="text" class="form-control" id="idSFTPPrefix" name="sftp_prefix" placeholder=""
@@ -299,7 +299,7 @@
             </div>
         </div>
 
-        <div class="form-group sftp">
+        <div class="form-group fsconfig fsconfig-sftpfs">
             <div class="form-check">
                 <input type="checkbox" class="form-check-input" id="idDisableConcurrentReads"
                     name="sftp_disable_concurrent_reads" {{if .SFTPConfig.DisableCouncurrentReads}}checked{{end}}>
@@ -312,28 +312,10 @@
 
 {{define "fsjs"}}
     function onFilesystemChanged(val){
-        // first hide all fsconfig sections
-        $('.form-group.row.gcs').hide();
-        $('.form-group.gcs').hide();
-        $('.form-group.row.s3').hide();
-        $('.form-group.row.azblob').hide();
-        $('.form-group.azblob').hide();
-        $('.form-group.crypt').hide();
-        $('.form-group.sftp').hide();
-
-        // enable the ones matching the selected vfs provider
-        if (val == 's3fs'){
-            $('.form-group.row.s3').show();
-        } else if (val == 'gcsfs'){
-            $('.form-group.row.gcs').show();
-            $('.form-group.gcs').show();
-        } else if (val == 'azblobfs'){
-            $('.form-group.row.azblob').show();
-            $('.form-group.azblob').show();
-        } else if (val == 'cryptfs'){
-            $('.form-group.crypt').show();
-        } else if (val == 'sftpfs'){
-            $('.form-group.sftp').show();
-        }
+        // each fsconfig form-group has the 'fsconfig' css class
+        // as well as a 'fsconfig-{name}' class where name is the FilesystemProvider.Name
+        // we're simply hiding all of them and then showing the ones that match the selected vfs provider
+        $('.form-group.fsconfig').hide();
+        $('.form-group.fsconfig-'+val).show();
     }
 {{end}}

--- a/templates/webadmin/fsconfig.html
+++ b/templates/webadmin/fsconfig.html
@@ -6,12 +6,9 @@
             <div class="col-sm-10">
                 <select class="form-control" id="idFilesystem" name="fs_provider"
                     onchange="onFilesystemChanged(this.value)">
-                    <option value="0" {{if eq .Provider 0 }}selected{{end}}>Local</option>
-                    <option value="4" {{if eq .Provider 4 }}selected{{end}}>Local encrypted</option>
-                    <option value="1" {{if eq .Provider 1 }}selected{{end}}>AWS S3 (Compatible)</option>
-                    <option value="2" {{if eq .Provider 2 }}selected{{end}}>Google Cloud Storage</option>
-                    <option value="3" {{if eq .Provider 3 }}selected{{end}}>Azure Blob Storage</option>
-                    <option value="5" {{if eq .Provider 5 }}selected{{end}}>SFTP</option>
+                    {{ range ListFSProviders }}
+                    <option value="{{.}}" {{if eq . $.Provider }}selected{{end}}>{{.ShortInfo}}</option>
+                    {{end}}
                 </select>
             </div>
         </div>

--- a/templates/webadmin/fsconfig.html
+++ b/templates/webadmin/fsconfig.html
@@ -7,7 +7,7 @@
                 <select class="form-control" id="idFilesystem" name="fs_provider"
                     onchange="onFilesystemChanged(this.value)">
                     {{ range ListFSProviders }}
-                    <option value="{{.}}" {{if eq . $.Provider }}selected{{end}}>{{.ShortInfo}}</option>
+                    <option value="{{.Name}}" {{if eq . $.Provider }}selected{{end}}>{{.ShortInfo}}</option>
                     {{end}}
                 </select>
             </div>
@@ -322,17 +322,17 @@
         $('.form-group.sftp').hide();
 
         // enable the ones matching the selected vfs provider
-        if (val == '1'){
+        if (val == 's3fs'){
             $('.form-group.row.s3').show();
-        } else if (val == '2'){
+        } else if (val == 'gcsfs'){
             $('.form-group.row.gcs').show();
             $('.form-group.gcs').show();
-        } else if (val == '3'){
+        } else if (val == 'azblobfs'){
             $('.form-group.row.azblob').show();
             $('.form-group.azblob').show();
-        } else if (val == '4'){
+        } else if (val == 'cryptfs'){
             $('.form-group.crypt').show();
-        } else if (val == '5'){
+        } else if (val == 'sftpfs'){
             $('.form-group.sftp').show();
         }
     }

--- a/templates/webadmin/fsconfig.html
+++ b/templates/webadmin/fsconfig.html
@@ -315,54 +315,28 @@
 
 {{define "fsjs"}}
     function onFilesystemChanged(val){
+        // first hide all fsconfig sections
+        $('.form-group.row.gcs').hide();
+        $('.form-group.gcs').hide();
+        $('.form-group.row.s3').hide();
+        $('.form-group.row.azblob').hide();
+        $('.form-group.azblob').hide();
+        $('.form-group.crypt').hide();
+        $('.form-group.sftp').hide();
+
+        // enable the ones matching the selected vfs provider
         if (val == '1'){
-            $('.form-group.row.gcs').hide();
-            $('.form-group.gcs').hide();
-            $('.form-group.row.azblob').hide();
-            $('.form-group.azblob').hide();
-            $('.form-group.crypt').hide();
-            $('.form-group.sftp').hide();
             $('.form-group.row.s3').show();
         } else if (val == '2'){
             $('.form-group.row.gcs').show();
             $('.form-group.gcs').show();
-            $('.form-group.row.azblob').hide();
-            $('.form-group.azblob').hide();
-            $('.form-group.crypt').hide();
-            $('.form-group.row.s3').hide();
-            $('.form-group.sftp').hide();
         } else if (val == '3'){
             $('.form-group.row.azblob').show();
             $('.form-group.azblob').show();
-            $('.form-group.row.gcs').hide();
-            $('.form-group.gcs').hide();
-            $('.form-group.crypt').hide();
-            $('.form-group.row.s3').hide();
-            $('.form-group.sftp').hide();
         } else if (val == '4'){
-            $('.form-group.row.gcs').hide();
-            $('.form-group.gcs').hide();
-            $('.form-group.row.s3').hide();
-            $('.form-group.row.azblob').hide();
-            $('.form-group.azblob').hide();
             $('.form-group.crypt').show();
-            $('.form-group.sftp').hide();
         } else if (val == '5'){
-            $('.form-group.row.gcs').hide();
-            $('.form-group.gcs').hide();
-            $('.form-group.row.s3').hide();
-            $('.form-group.row.azblob').hide();
-            $('.form-group.azblob').hide();
-            $('.form-group.crypt').hide();
             $('.form-group.sftp').show();
-        } else {
-            $('.form-group.row.gcs').hide();
-            $('.form-group.gcs').hide();
-            $('.form-group.row.s3').hide();
-            $('.form-group.row.azblob').hide();
-            $('.form-group.azblob').hide();
-            $('.form-group.crypt').hide();
-            $('.form-group.sftp').hide();
         }
     }
 {{end}}

--- a/templates/webadmin/user.html
+++ b/templates/webadmin/user.html
@@ -635,7 +635,7 @@
             return true;
         });
 
-        onFilesystemChanged('{{.User.FsConfig.Provider}}');
+        onFilesystemChanged('{{.User.FsConfig.Provider.Name}}');
 
         $("body").on("click", ".add_new_pk_field_btn", function () {
             var index = $(".form_field_pk_outer").find(".form_field_pk_outer_row").length;

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -353,9 +353,22 @@ func CleanPath(p string) string {
 	return path.Clean(p)
 }
 
-// LoadTemplate wraps a call to a function returning (*Template, error)
-// it is just like template.Must but it writes a log before exiting
-func LoadTemplate(t *template.Template, err error) *template.Template {
+// LoadTemplate parses the given template paths.
+// it behaves like template.Must but it writes a log before exiting
+// you can optionally provide a base template (e.g. to define some custom functions)
+func LoadTemplate(base *template.Template, paths ...string) *template.Template {
+	var t *template.Template
+	var err error
+
+	if base != nil {
+		t, err = base.ParseFiles(paths...)
+		if err == nil {
+			t, err = t.Clone()
+		}
+	} else {
+		t, err = template.ParseFiles(paths...)
+	}
+
 	if err != nil {
 		logger.ErrorToConsole("error loading required template: %v", err)
 		logger.Error(logSender, "", "error loading required template: %v", err)

--- a/vfs/filesystem.go
+++ b/vfs/filesystem.go
@@ -43,6 +43,44 @@ func GetProviderByName(name string) FilesystemProvider {
 	return LocalFilesystemProvider
 }
 
+// Name returns the Provider's unique name
+func (p FilesystemProvider) Name() string {
+	switch p {
+	case LocalFilesystemProvider:
+		return "osfs"
+	case S3FilesystemProvider:
+		return "s3fs"
+	case GCSFilesystemProvider:
+		return "gcsfs"
+	case AzureBlobFilesystemProvider:
+		return "azblobfs"
+	case CryptedFilesystemProvider:
+		return "cryptfs"
+	case SFTPFilesystemProvider:
+		return "sftpfs"
+	}
+	return "" // let's not claim to be
+}
+
+// ShortInfo returns a human readable, short description for the given FilesystemProvider
+func (p FilesystemProvider) ShortInfo() string {
+	switch p {
+	case LocalFilesystemProvider:
+		return "Local"
+	case S3FilesystemProvider:
+		return "S3"
+	case GCSFilesystemProvider:
+		return "GCS"
+	case AzureBlobFilesystemProvider:
+		return "AzBlob"
+	case CryptedFilesystemProvider:
+		return "Encrypted"
+	case SFTPFilesystemProvider:
+		return "SFTP"
+	}
+	return ""
+}
+
 // ValidatorHelper implements methods we need for Filesystem.ValidateConfig.
 // It is implemented by vfs.Folder and dataprovider.User
 type ValidatorHelper interface {

--- a/vfs/filesystem.go
+++ b/vfs/filesystem.go
@@ -20,6 +20,29 @@ const (
 	SFTPFilesystemProvider                                // SFTP
 )
 
+// GetProviderByName returns the FilesystemProvider matching a given name
+//
+// to provide backwards compatibility, numeric strings are accepted as well
+func GetProviderByName(name string) FilesystemProvider {
+	switch name {
+	case "0", "osfs":
+		return LocalFilesystemProvider
+	case "1", "s3fs":
+		return S3FilesystemProvider
+	case "2", "gcsfs":
+		return GCSFilesystemProvider
+	case "3", "azblobfs":
+		return AzureBlobFilesystemProvider
+	case "4", "cryptfs":
+		return CryptedFilesystemProvider
+	case "5", "sftpfs":
+		return SFTPFilesystemProvider
+	}
+
+	// TODO think about returning an error value instead of silently defaulting to LocalFilesystemProvider
+	return LocalFilesystemProvider
+}
+
 // ValidatorHelper implements methods we need for Filesystem.ValidateConfig.
 // It is implemented by vfs.Folder and dataprovider.User
 type ValidatorHelper interface {

--- a/vfs/filesystem.go
+++ b/vfs/filesystem.go
@@ -68,17 +68,27 @@ func (p FilesystemProvider) ShortInfo() string {
 	case LocalFilesystemProvider:
 		return "Local"
 	case S3FilesystemProvider:
-		return "S3"
+		return "AWS S3 (Compatible)"
 	case GCSFilesystemProvider:
-		return "GCS"
+		return "Google Cloud Storage"
 	case AzureBlobFilesystemProvider:
-		return "AzBlob"
+		return "Azure Blob Storage"
 	case CryptedFilesystemProvider:
-		return "Encrypted"
+		return "Local encrypted"
 	case SFTPFilesystemProvider:
 		return "SFTP"
 	}
 	return ""
+}
+
+// ListProviders returns a list of available FilesystemProviders
+func ListProviders() []FilesystemProvider {
+	// TODO this should ultimately be dynamic (i.e. each provider registers itself)
+	return []FilesystemProvider{
+		LocalFilesystemProvider, S3FilesystemProvider,
+		GCSFilesystemProvider, AzureBlobFilesystemProvider,
+		CryptedFilesystemProvider, SFTPFilesystemProvider,
+	}
 }
 
 // ValidatorHelper implements methods we need for Filesystem.ValidateConfig.


### PR DESCRIPTION
This PR is related to #449 (look there for further details).

Right now vfs implementations use numeric IDs (`vfs.*FilesystemProvider`).
These IDs are implementation specific and even hard-coded in some places (e.g. `templates/webadmin/fsconfig.html` or some of the commandline flags)

This can lead to ID clashes and makes it pretty much impossible to maintain custom vfs implementations outside the main sftpgo project:
- let's say I write a custom vfs wrapper around `s3fs`. I name it `vfs.SomeFilesystemProvider` and it gets ID#6 in my source tree.  
  it ends up being too specific to my individual use case and thus won''t be accepted into the main sftpgo project.  
  I keep maintaining it in a separate fork on github.
- the official sftpgo project later adds support for `AnotherFilesystemProvider` - also assigning ID#6 to it
- anyone using non-mainstream vfs implementations now have to mitigate that conflict


This PR introduces new string IDs and a few methods to help using them:

- vfs.GetProviderByName() returns the `FilesystemProvider` for any given string name.
  for backwards compatibility "0" returns `LocalFSP`, "1" returns `S3FSP`, etc
- `vfs.ListProviders()` returns a list of all configured vfs implementations. Right now it's hardcoded, but ultimately each FilesystemProvider should probably register itself.
- removed vfs-specific code from `templates/webadmin/fsconfig.html`
- removed vfs-specific code from `User.GetInfoString()`

I've used the file names of the individual `vfs/*.go` files for these string IDs (I'm open to other suggestions)

----

For now all changes are in code only. `vfs.Filesystem.Provider` is still an integer field (I won't mess with JSON config or API compatibility without a discussion first)