### PR TITLE
updated username regex (and error messages) to allow backslashes

### DIFF
--- a/dataprovider/admin.go
+++ b/dataprovider/admin.go
@@ -108,7 +108,7 @@ func (a *Admin) validate() error {
 		return util.NewValidationError("please set a password")
 	}
 	if !config.SkipNaturalKeysValidation && !usernameRegex.MatchString(a.Username) {
-		return util.NewValidationError(fmt.Sprintf("username %#v is not valid, the following characters are allowed: a-zA-Z0-9-_.~", a.Username))
+		return util.NewValidationError(fmt.Sprintf("username %#v is not valid, the following characters are allowed: a-zA-Z0-9-_.~\\", a.Username))
 	}
 	if err := a.checkPassword(); err != nil {
 		return err

--- a/dataprovider/dataprovider.go
+++ b/dataprovider/dataprovider.go
@@ -149,7 +149,7 @@ var (
 	sqlTableSchemaVersion   = "schema_version"
 	argon2Params            *argon2id.Params
 	lastLoginMinDelay       = 10 * time.Minute
-	usernameRegex           = regexp.MustCompile("^[a-zA-Z0-9-_.~]+$")
+	usernameRegex           = regexp.MustCompile("^[a-zA-Z0-9-_.~\\\\]+$")
 	tempPath                string
 )
 
@@ -1528,7 +1528,7 @@ func validateBaseParams(user *User) error {
 		return util.NewValidationError("username is mandatory")
 	}
 	if !config.SkipNaturalKeysValidation && !usernameRegex.MatchString(user.Username) {
-		return util.NewValidationError(fmt.Sprintf("username %#v is not valid, the following characters are allowed: a-zA-Z0-9-_.~",
+		return util.NewValidationError(fmt.Sprintf("username %#v is not valid, the following characters are allowed: a-zA-Z0-9-_.~\\",
 			user.Username))
 	}
 	if user.HomeDir == "" {
@@ -1575,7 +1575,7 @@ func ValidateFolder(folder *vfs.BaseVirtualFolder) error {
 		return util.NewValidationError("folder name is mandatory")
 	}
 	if !config.SkipNaturalKeysValidation && !usernameRegex.MatchString(folder.Name) {
-		return util.NewValidationError(fmt.Sprintf("folder name %#v is not valid, the following characters are allowed: a-zA-Z0-9-_.~",
+		return util.NewValidationError(fmt.Sprintf("folder name %#v is not valid, the following characters are allowed: a-zA-Z0-9-_.~\\",
 			folder.Name))
 	}
 	if folder.FsConfig.Provider == sdk.LocalFilesystemProvider || folder.FsConfig.Provider == sdk.CryptedFilesystemProvider ||


### PR DESCRIPTION
backslash characters, although admittedly sound suboptimal, actually work perfectly fine as usernames within SFTPGo. in fact, you can create users with backslashes as part of their names directly in the database even without this PR, but you can no longer change any settings in the user afterwards because it fails the regex validation.

this PR merely adds the backslash character to the regex and error messages. there are four backslashes in the regex because both regular expressions _and_ Go strings require backslash characters to be escaped.

tested:

- SFTP with OpenSSH's `sftp` command line tool
- WebDAV with WinSCP
- FTP with both the Linux command line tool, Windows Explorer, and WinSCP for good measure