### PR TITLE
Parse auth plugin information from env

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -697,6 +697,18 @@ func getKMSPluginFromEnv(idx int, pluginConfig *plugin.Config) bool {
 	return isSet
 }
 
+func getAuthPluginFromEnv(idx int, pluginConfig *plugin.Config) bool {
+	isSet := false
+
+	authScope, ok := lookupIntFromEnv(fmt.Sprintf("SFTPGO_PLUGINS__%v__AUTH_OPTIONS__SCOPE", idx))
+	if ok {
+		pluginConfig.AuthOptions.Scope = int(authScope)
+		isSet = true
+	}
+
+	return isSet
+}
+
 func getNotifierPluginFromEnv(idx int, pluginConfig *plugin.Config) bool {
 	isSet := false
 
@@ -752,6 +764,10 @@ func getPluginsFromEnv(idx int) {
 	}
 
 	if getKMSPluginFromEnv(idx, &pluginConfig) {
+		isSet = true
+	}
+
+	if getAuthPluginFromEnv(idx, &pluginConfig) {
 		isSet = true
 	}
 

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -440,6 +440,7 @@ func TestPluginsFromEnv(t *testing.T) {
 	os.Setenv("SFTPGO_PLUGINS__0__AUTO_MTLS", "1")
 	os.Setenv("SFTPGO_PLUGINS__0__KMS_OPTIONS__SCHEME", kms.SchemeAWS)
 	os.Setenv("SFTPGO_PLUGINS__0__KMS_OPTIONS__ENCRYPTED_STATUS", kms.SecretStatusAWS)
+	os.Setenv("SFTPGO_PLUGINS__0__AUTH_OPTIONS__SCOPE", "14")
 	t.Cleanup(func() {
 		os.Unsetenv("SFTPGO_PLUGINS__0__TYPE")
 		os.Unsetenv("SFTPGO_PLUGINS__0__NOTIFIER_OPTIONS__FS_EVENTS")
@@ -453,6 +454,7 @@ func TestPluginsFromEnv(t *testing.T) {
 		os.Unsetenv("SFTPGO_PLUGINS__0__AUTO_MTLS")
 		os.Unsetenv("SFTPGO_PLUGINS__0__KMS_OPTIONS__SCHEME")
 		os.Unsetenv("SFTPGO_PLUGINS__0__KMS_OPTIONS__ENCRYPTED_STATUS")
+		os.Unsetenv("SFTPGO_PLUGINS__0__AUTH_OPTIONS__SCOPE")
 	})
 
 	configDir := ".."
@@ -481,6 +483,7 @@ func TestPluginsFromEnv(t *testing.T) {
 	require.True(t, pluginConf.AutoMTLS)
 	require.Equal(t, kms.SchemeAWS, pluginConf.KMSOptions.Scheme)
 	require.Equal(t, kms.SecretStatusAWS, pluginConf.KMSOptions.EncryptedStatus)
+	require.Equal(t, 14, pluginConf.AuthOptions.Scope)
 
 	configAsJSON, err := json.Marshal(pluginsConf)
 	require.NoError(t, err)
@@ -517,6 +520,7 @@ func TestPluginsFromEnv(t *testing.T) {
 	require.False(t, pluginConf.AutoMTLS)
 	require.Equal(t, kms.SchemeVaultTransit, pluginConf.KMSOptions.Scheme)
 	require.Equal(t, kms.SecretStatusVaultTransit, pluginConf.KMSOptions.EncryptedStatus)
+	require.Equal(t, 14, pluginConf.AuthOptions.Scope)
 
 	err = os.Remove(configFilePath)
 	assert.NoError(t, err)


### PR DESCRIPTION
Parse `AuthOptions.Scope` from `SFTPGO_PLUGINS__{{idx}}__AUTH_OPTIONS__SCOPE`
if set.

Fixes #595
