### PR TITLE
systemd-security: add some easy wins

### DIFF
--- a/init/sftpgo.service
+++ b/init/sftpgo.service
@@ -17,6 +17,11 @@ KillMode=mixed
 PrivateTmp=true
 Restart=always
 RestartSec=10s
+NoNewPrivileges=yes
+PrivateDevices=yes
+DevicePolicy=closed
+ProtectSystem=true
+RestrictAddressFamilies=AF_INET AF_INET6 AF_UNIX
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
We can tighten security by adding the following to the systemd service file. Please tell me if my assumptions are wrong somewhere - I tested this with my local setup and it works fine, this should not compromise any functionality while removing potentially hazardous capabilities.

* NoNewPrivileges: should never be needed
* DevicePolicy: only basics required
* PrivateDevices: only needs mounted stuff for file access anyhow, never devices or memory or whatever
* ProtectSystem: no need to change boot or other critical files
* RestrictAddressFamilies: INET and UNIX only, no need for any other address families

Thanks for this project, it's amazing.

Cheers!