### PR TITLE
httpd: webpath redirect using status found (302)

### DIFF
--- a/httpd/httpd_test.go
+++ b/httpd/httpd_test.go
@@ -7968,19 +7968,19 @@ func TestHealthCheck(t *testing.T) {
 func TestGetWebRootMock(t *testing.T) {
 	req, _ := http.NewRequest(http.MethodGet, "/", nil)
 	rr := executeRequest(req)
-	checkResponseCode(t, http.StatusMovedPermanently, rr)
+	checkResponseCode(t, http.StatusFound, rr)
 	assert.Equal(t, webClientLoginPath, rr.Header().Get("Location"))
 	req, _ = http.NewRequest(http.MethodGet, webBasePath, nil)
 	rr = executeRequest(req)
-	checkResponseCode(t, http.StatusMovedPermanently, rr)
+	checkResponseCode(t, http.StatusFound, rr)
 	assert.Equal(t, webClientLoginPath, rr.Header().Get("Location"))
 	req, _ = http.NewRequest(http.MethodGet, webBasePathAdmin, nil)
 	rr = executeRequest(req)
-	checkResponseCode(t, http.StatusMovedPermanently, rr)
+	checkResponseCode(t, http.StatusFound, rr)
 	assert.Equal(t, webLoginPath, rr.Header().Get("Location"))
 	req, _ = http.NewRequest(http.MethodGet, webBasePathClient, nil)
 	rr = executeRequest(req)
-	checkResponseCode(t, http.StatusMovedPermanently, rr)
+	checkResponseCode(t, http.StatusFound, rr)
 	assert.Equal(t, webClientLoginPath, rr.Header().Get("Location"))
 }
 

--- a/httpd/internal_test.go
+++ b/httpd/internal_test.go
@@ -1649,14 +1649,14 @@ func TestWebAdminRedirect(t *testing.T) {
 	assert.NoError(t, err)
 	rr := httptest.NewRecorder()
 	testServer.Config.Handler.ServeHTTP(rr, req)
-	assert.Equal(t, http.StatusMovedPermanently, rr.Code, rr.Body.String())
+	assert.Equal(t, http.StatusFound, rr.Code, rr.Body.String())
 	assert.Equal(t, webLoginPath, rr.Header().Get("Location"))
 
 	req, err = http.NewRequest(http.MethodGet, webBasePath, nil)
 	assert.NoError(t, err)
 	rr = httptest.NewRecorder()
 	testServer.Config.Handler.ServeHTTP(rr, req)
-	assert.Equal(t, http.StatusMovedPermanently, rr.Code, rr.Body.String())
+	assert.Equal(t, http.StatusFound, rr.Code, rr.Body.String())
 	assert.Equal(t, webLoginPath, rr.Header().Get("Location"))
 }
 

--- a/httpd/server.go
+++ b/httpd/server.go
@@ -943,7 +943,7 @@ func (s *httpdServer) sendForbiddenResponse(w http.ResponseWriter, r *http.Reque
 
 func (s *httpdServer) redirectToWebPath(w http.ResponseWriter, r *http.Request, webPath string) {
 	if dataprovider.HasAdmin() {
-		http.Redirect(w, r, webPath, http.StatusMovedPermanently)
+		http.Redirect(w, r, webPath, http.StatusFound)
 		return
 	}
 	if s.enableWebAdmin {
@@ -1200,7 +1200,7 @@ func (s *httpdServer) initializeRouter() {
 	if s.enableWebClient {
 		s.router.Get(webBaseClientPath, func(w http.ResponseWriter, r *http.Request) {
 			r.Body = http.MaxBytesReader(w, r.Body, maxRequestSize)
-			http.Redirect(w, r, webClientLoginPath, http.StatusMovedPermanently)
+			http.Redirect(w, r, webClientLoginPath, http.StatusFound)
 		})
 		s.router.Get(webClientLoginPath, s.handleClientWebLogin)
 		s.router.Post(webClientLoginPath, s.handleWebClientLoginPost)


### PR DESCRIPTION
301 MovedPermanently is cached by the browser which can
be annoying when it is is on base path like / while one
may reuse the domain (e.g. localhost) for other apps/tests.

Fixes #695

Signed-off-by: Jeremy Clerc <jeremy@clerc.io>