### PR TITLE
add build flag to entirely disable journald logger

### DIFF
--- a/docs/build-from-source.md
+++ b/docs/build-from-source.md
@@ -8,6 +8,7 @@ The following build tags are available:
 - `nos3`, disable S3 Compabible Object Storage backends, default enabled
 - `noazblob`, disable Azure Blob Storage backend, default enabled
 - `nobolt`, disable Bolt data provider, default enabled
+- `nojournald`, disable journald logger, default enabled
 - `nomysql`, disable MySQL data provider, default enabled
 - `nopgsql`, disable PostgreSQL data provider, default enabled
 - `nosqlite`, disable SQLite data provider, default enabled

--- a/logger/journald.go
+++ b/logger/journald.go
@@ -1,5 +1,5 @@
-//go:build linux
-// +build linux
+//go:build linux && !nojournald
+// +build linux,!nojournald
 
 package logger
 

--- a/logger/journald_nolinux.go
+++ b/logger/journald_nolinux.go
@@ -1,5 +1,5 @@
-//go:build !linux
-// +build !linux
+//go:build !linux || nojournald
+// +build !linux nojournald
 
 package logger
 


### PR DESCRIPTION
The library used to log to journald go-systemd always creates
a socket on init, no matter if you'll use it or not:

https://github.com/coreos/go-systemd/blob/9ed442a88da2e6230e1d13be1820a5357055aec8/journal/journal_unix.go#L56

Journald logging is "eventually" available only in the subsystem
and only if the user decides to activate.

No matter which part of sftpgo you use, there is always somewhere
where you include the sftpgo/logger, even `sftpgo help` and so
you always get a socket.

This change adds a build flag so sftpgo can be built without
go-systemd/journal dependency and so prevent the creation of
a socket that will not be used.