### PR TITLE
Deny file rename in directories with Upload/Delete permissions and missing rename permission

### DIFF
--- a/common/connection.go
+++ b/common/connection.go
@@ -830,11 +830,11 @@ func (c *BaseConnection) hasRenamePerms(virtualSourcePath, virtualTargetPath str
 		return c.User.HasPerm(dataprovider.PermCreateDirs, path.Dir(virtualTargetPath))
 	}
 	// file or symlink
-	if c.User.HasPerm(dataprovider.PermRenameFiles, path.Dir(virtualSourcePath)) &&
-		c.User.HasPerm(dataprovider.PermRenameFiles, path.Dir(virtualTargetPath)) {
-		return true
-	}
 	if !c.User.HasAnyPerm([]string{dataprovider.PermDeleteFiles, dataprovider.PermDelete}, path.Dir(virtualSourcePath)) {
+		return false
+	}
+	if !c.User.HasPerm(dataprovider.PermRenameFiles, path.Dir(virtualSourcePath)) ||
+		!c.User.HasPerm(dataprovider.PermRenameFiles, path.Dir(virtualTargetPath)) {
 		return false
 	}
 	if fi.Mode()&os.ModeSymlink != 0 {


### PR DESCRIPTION
I believe there is a bug here in the connection class. It seems that users will be allowed to rename files in the scenario that they have delete/upload permission to a sub directory, but do not have rename permissions.

From my local testing it seems that omitting the rename permission still allows renames to happen. Please let me know what you think.