### PR TITLE
always show banned host in ui

### DIFF
--- a/dataprovider/sqlqueries.go
+++ b/dataprovider/sqlqueries.go
@@ -47,7 +47,7 @@ func getAddDefenderEventQuery() string {
 }
 
 func getDefenderHostsQuery() string {
-	return fmt.Sprintf(`SELECT id,ip,ban_time FROM %v WHERE updated_at >= %v ORDER BY updated_at DESC LIMIT %v`,
+	return fmt.Sprintf(`SELECT id,ip,ban_time FROM %v WHERE updated_at >= %v OR ban_time > 0 ORDER BY updated_at DESC LIMIT %v`,
 		sqlTableDefenderHosts, sqlPlaceholders[0], sqlPlaceholders[1])
 }
 


### PR DESCRIPTION
When an host is banned but the updated_time field is in the past the ui didn't show the record.

Fixes #758