### PR TITLE
Add flag to indicate if protocol is secure to hooks

### DIFF
--- a/ftpd/server.go
+++ b/ftpd/server.go
@@ -187,7 +187,7 @@ func (s *Server) AuthUser(cc ftpserver.ClientContext, username, password string)
 		loginMethod = dataprovider.LoginMethodTLSCertificateAndPwd
 	}
 	ipAddr := util.GetIPFromRemoteAddress(cc.RemoteAddr().String())
-	user, err := dataprovider.CheckUserAndPass(username, password, ipAddr, common.ProtocolFTP)
+	user, err := dataprovider.CheckUserAndPass(username, password, ipAddr, common.ProtocolFTP, cc.HasTLSForControl())
 	if err != nil {
 		user.Username = username
 		updateLoginMetrics(&user, ipAddr, loginMethod, err)
@@ -225,7 +225,7 @@ func (s *Server) VerifyConnection(cc ftpserver.ClientContext, user string, tlsCo
 		state := tlsConn.ConnectionState()
 		if len(state.PeerCertificates) > 0 {
 			ipAddr := util.GetIPFromRemoteAddress(cc.RemoteAddr().String())
-			dbUser, err := dataprovider.CheckUserBeforeTLSAuth(user, ipAddr, common.ProtocolFTP, state.PeerCertificates[0])
+			dbUser, err := dataprovider.CheckUserBeforeTLSAuth(user, ipAddr, common.ProtocolFTP, true, state.PeerCertificates[0])
 			if err != nil {
 				dbUser.Username = user
 				updateLoginMetrics(&dbUser, ipAddr, dataprovider.LoginMethodTLSCertificate, err)

--- a/httpd/api_http_user.go
+++ b/httpd/api_http_user.go
@@ -519,7 +519,7 @@ func doChangeUserPassword(r *http.Request, currentPassword, newPassword, confirm
 		return errors.New("invalid token claims")
 	}
 	_, err = dataprovider.CheckUserAndPass(claims.Username, currentPassword, util.GetIPFromRemoteAddress(r.RemoteAddr),
-		getProtocolFromRequest(r))
+		getProtocolFromRequest(r), r.TLS != nil)
 	if err != nil {
 		return util.NewValidationError("current password does not match")
 	}

--- a/httpd/httpd_test.go
+++ b/httpd/httpd_test.go
@@ -904,11 +904,11 @@ func TestGroupSettingsOverride(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Len(t, user.VirtualFolders, 0)
 
-	user, err = dataprovider.CheckUserAndPass(defaultUsername, defaultPassword, "", common.ProtocolHTTP)
+	user, err = dataprovider.CheckUserAndPass(defaultUsername, defaultPassword, "", common.ProtocolHTTP, false)
 	assert.NoError(t, err)
 	assert.Len(t, user.VirtualFolders, 3)
 
-	user, err = dataprovider.GetUserAfterIDPAuth(defaultUsername, "", common.ProtocolOIDC, nil)
+	user, err = dataprovider.GetUserAfterIDPAuth(defaultUsername, "", common.ProtocolOIDC, false, nil)
 	assert.NoError(t, err)
 	assert.Len(t, user.VirtualFolders, 3)
 
@@ -936,7 +936,7 @@ func TestGroupSettingsOverride(t *testing.T) {
 	group2.UserSettings.Filters.WebClient = []string{sdk.WebClientInfoChangeDisabled, sdk.WebClientMFADisabled}
 	_, _, err = httpdtest.UpdateGroup(group2, http.StatusOK)
 	assert.NoError(t, err)
-	user, err = dataprovider.CheckUserAndPass(defaultUsername, defaultPassword, "", common.ProtocolHTTP)
+	user, err = dataprovider.CheckUserAndPass(defaultUsername, defaultPassword, "", common.ProtocolHTTP, false)
 	assert.NoError(t, err)
 	assert.Len(t, user.VirtualFolders, 3)
 	assert.Equal(t, sdk.LocalFilesystemProvider, user.FsConfig.Provider)
@@ -979,7 +979,7 @@ func TestGroupSettingsOverride(t *testing.T) {
 	}
 	_, _, err = httpdtest.UpdateGroup(group1, http.StatusOK)
 	assert.NoError(t, err)
-	user, err = dataprovider.CheckUserAndPass(defaultUsername, defaultPassword, "", common.ProtocolHTTP)
+	user, err = dataprovider.CheckUserAndPass(defaultUsername, defaultPassword, "", common.ProtocolHTTP, false)
 	assert.NoError(t, err)
 	assert.Len(t, user.VirtualFolders, 3)
 	assert.Equal(t, sdk.SFTPFilesystemProvider, user.FsConfig.Provider)

--- a/httpd/oidc.go
+++ b/httpd/oidc.go
@@ -318,7 +318,7 @@ func (t *oidcToken) getUser(r *http.Request) error {
 		return nil
 	}
 	ipAddr := util.GetIPFromRemoteAddress(r.RemoteAddr)
-	user, err := dataprovider.GetUserAfterIDPAuth(t.Username, ipAddr, common.ProtocolOIDC, t.CustomFields)
+	user, err := dataprovider.GetUserAfterIDPAuth(t.Username, ipAddr, common.ProtocolOIDC, r.TLS != nil, t.CustomFields)
 	if err != nil {
 		return err
 	}

--- a/httpd/server.go
+++ b/httpd/server.go
@@ -221,7 +221,7 @@ func (s *httpdServer) handleWebClientLoginPost(w http.ResponseWriter, r *http.Re
 		return
 	}
 
-	user, err := dataprovider.CheckUserAndPass(username, password, ipAddr, protocol)
+	user, err := dataprovider.CheckUserAndPass(username, password, ipAddr, protocol, r.TLS != nil)
 	if err != nil {
 		updateLoginMetrics(&user, dataprovider.LoginMethodPassword, ipAddr, err)
 		s.renderClientLoginPage(w, dataprovider.ErrInvalidCredentials.Error(), ipAddr)
@@ -747,7 +747,7 @@ func (s *httpdServer) getUserToken(w http.ResponseWriter, r *http.Request) {
 		sendAPIResponse(w, r, err, http.StatusText(http.StatusForbidden), http.StatusForbidden)
 		return
 	}
-	user, err := dataprovider.CheckUserAndPass(username, password, ipAddr, protocol)
+	user, err := dataprovider.CheckUserAndPass(username, password, ipAddr, protocol, r.TLS != nil)
 	if err != nil {
 		w.Header().Set(common.HTTPAuthenticationHeader, basicRealm)
 		updateLoginMetrics(&user, dataprovider.LoginMethodPassword, ipAddr, err)

--- a/sftpd/server.go
+++ b/sftpd/server.go
@@ -1045,7 +1045,7 @@ func (c *Configuration) validatePasswordCredentials(conn ssh.ConnMetadata, pass 
 		method = dataprovider.SSHLoginMethodKeyAndPassword
 	}
 	ipAddr := util.GetIPFromRemoteAddress(conn.RemoteAddr().String())
-	if user, err = dataprovider.CheckUserAndPass(conn.User(), string(pass), ipAddr, common.ProtocolSSH); err == nil {
+	if user, err = dataprovider.CheckUserAndPass(conn.User(), string(pass), ipAddr, common.ProtocolSSH, true); err == nil {
 		sshPerm, err = loginUser(&user, method, "", conn)
 	}
 	user.Username = conn.User()

--- a/webdavd/server.go
+++ b/webdavd/server.go
@@ -280,7 +280,7 @@ func (s *webDavServer) authenticate(r *http.Request, ip string) (dataprovider.Us
 		}
 	}
 	user, loginMethod, err = dataprovider.CheckCompositeCredentials(username, password, ip, loginMethod,
-		common.ProtocolWebDAV, tlsCert)
+		common.ProtocolWebDAV, r.TLS != nil, tlsCert)
 	if err != nil {
 		user.Username = username
 		updateLoginMetrics(&user, ip, loginMethod, err)


### PR DESCRIPTION
The aim of this is to add the ability to allow/deny access based on if they are connecting with a 'secure' protocol, i.e. if it is FTP or FTPS, or HTTP vs HTTPS.

Use case: if supporting legacy software that only supports FTP we would want to allow the connection for plaintext FTP but deny plaintext FTP for all other users.

At the moment this is not possible (from what I can see), as only the protocol (HTTP, FTP, SFTP...) is passed in the pre-login hook without any detail around the client connection.

There might be a better way of achieving this with more detail passed to the hook, but thought this would suit as a proof of concept initially.

If this seems like a reasonable change, I think it would also be worthwhile adding to the other hooks (connection / external auth) where applicable. Understandably some won't be able to determine if it's secure at time of hook (connection hooks for explicit FTPS would likely show as insecure if the hook occurs before TLS negotiation).

I wasn't able to get the test suite to run fully to check if these changes are working as expected, is there any docs on getting this set up for a dev environment?