### PR TITLE
chore: disallow all crawlers with robots.txt

### DIFF
--- a/httpd/httpd.go
+++ b/httpd/httpd.go
@@ -86,6 +86,7 @@ const (
 	providerEventsPath                    = "/api/v2/events/provider"
 	sharesPath                            = "/api/v2/shares"
 	healthzPath                           = "/healthz"
+	robotsTxtPath                         = "/robots.txt"
 	webRootPathDefault                    = "/"
 	webBasePathDefault                    = "/web"
 	webBasePathAdminDefault               = "/web/admin"

--- a/httpd/httpd_test.go
+++ b/httpd/httpd_test.go
@@ -118,6 +118,7 @@ const (
 	providerEventsPath              = "/api/v2/events/provider"
 	sharesPath                      = "/api/v2/shares"
 	healthzPath                     = "/healthz"
+	robotsTxtPath                   = "/robots.txt"
 	webBasePath                     = "/web"
 	webBasePathAdmin                = "/web/admin"
 	webAdminSetupPath               = "/web/admin/setup"
@@ -8908,6 +8909,13 @@ func TestHealthCheck(t *testing.T) {
 	rr := executeRequest(req)
 	checkResponseCode(t, http.StatusOK, rr)
 	assert.Equal(t, "ok", rr.Body.String())
+}
+
+func TestRobotsTxtCheck(t *testing.T) {
+	req, _ := http.NewRequest(http.MethodGet, "/robots.txt", nil)
+	rr := executeRequest(req)
+	checkResponseCode(t, http.StatusOK, rr)
+	assert.Equal(t, "User-agent: * Disallow: /", rr.Body.String())
 }
 
 func TestGetWebRootMock(t *testing.T) {

--- a/httpd/httpd_test.go
+++ b/httpd/httpd_test.go
@@ -8915,7 +8915,7 @@ func TestRobotsTxtCheck(t *testing.T) {
 	req, _ := http.NewRequest(http.MethodGet, "/robots.txt", nil)
 	rr := executeRequest(req)
 	checkResponseCode(t, http.StatusOK, rr)
-	assert.Equal(t, "User-agent: * Disallow: /", rr.Body.String())
+	assert.Equal(t, "User-agent: *\nDisallow: /", rr.Body.String())
 }
 
 func TestGetWebRootMock(t *testing.T) {

--- a/httpd/server.go
+++ b/httpd/server.go
@@ -1138,7 +1138,7 @@ func (s *httpdServer) initializeRouter() {
 	})
 
 	s.router.Get(robotsTxtPath, func(w http.ResponseWriter, r *http.Request) {
-		render.PlainText(w, r, "User-agent: * Disallow: /")
+		render.PlainText(w, r, "User-agent: *\nDisallow: /")
 	})
 
 	// share API exposed to external users

--- a/httpd/server.go
+++ b/httpd/server.go
@@ -1137,6 +1137,10 @@ func (s *httpdServer) initializeRouter() {
 		render.PlainText(w, r, "ok")
 	})
 
+	s.router.Get(robotsTxtPath, func(w http.ResponseWriter, r *http.Request) {
+		render.PlainText(w, r, "User-agent: * Disallow: /")
+	})
+
 	// share API exposed to external users
 	s.router.Get(sharesPath+"/{id}", s.downloadFromShare)
 	s.router.Post(sharesPath+"/{id}", s.uploadFilesToShare)


### PR DESCRIPTION
This adds a `/robots.txt` response to disallow all well-behaved bots. This was raised by one of our InfoSec people; I spent a little time disagreeing with them on the security aspect of `robots.txt` as bad actors and bad bots do not care about `/robots.txt`. They say you shouldn't wrestle a pig in mud, you both get dirty, and the pig likes it. 