### PR TITLE
chore: fix a linting error

### DIFF
--- a/httpd/httpd_test.go
+++ b/httpd/httpd_test.go
@@ -8905,14 +8905,14 @@ func TestMethodNotAllowedMock(t *testing.T) {
 }
 
 func TestHealthCheck(t *testing.T) {
-	req, _ := http.NewRequest(http.MethodGet, "/healthz", nil)
+	req, _ := http.NewRequest(http.MethodGet, healthzPath, nil)
 	rr := executeRequest(req)
 	checkResponseCode(t, http.StatusOK, rr)
 	assert.Equal(t, "ok", rr.Body.String())
 }
 
 func TestRobotsTxtCheck(t *testing.T) {
-	req, _ := http.NewRequest(http.MethodGet, "/robots.txt", nil)
+	req, _ := http.NewRequest(http.MethodGet, robotsTxtPath, nil)
 	rr := executeRequest(req)
 	checkResponseCode(t, http.StatusOK, rr)
 	assert.Equal(t, "User-agent: *\nDisallow: /", rr.Body.String())

--- a/vfs/statvfs_unix.go
+++ b/vfs/statvfs_unix.go
@@ -19,10 +19,10 @@ func getStatFS(path string) (*sftp.StatVFS, error) {
 		Frsize:  uint64(stat.Bsize),
 		Blocks:  stat.Blocks,
 		Bfree:   stat.Bfree,
-		Bavail:  uint64(stat.Bavail),
+		Bavail:  stat.Bavail,
 		Files:   stat.Files,
-		Ffree:   uint64(stat.Ffree),
-		Favail:  uint64(stat.Ffree), // not sure how to calculate Favail
+		Ffree:   stat.Ffree,
+		Favail:  stat.Ffree, // not sure how to calculate Favail
 		Flag:    uint64(stat.Flags),
 		Namemax: 255, // we use a conservative value here
 	}, nil

--- a/vfs/statvfs_unix.go
+++ b/vfs/statvfs_unix.go
@@ -19,10 +19,10 @@ func getStatFS(path string) (*sftp.StatVFS, error) {
 		Frsize:  uint64(stat.Bsize),
 		Blocks:  stat.Blocks,
 		Bfree:   stat.Bfree,
-		Bavail:  stat.Bavail,
+		Bavail:  uint64(stat.Bavail),
 		Files:   stat.Files,
-		Ffree:   stat.Ffree,
-		Favail:  stat.Ffree, // not sure how to calculate Favail
+		Ffree:   uint64(stat.Ffree),
+		Favail:  uint64(stat.Ffree), // not sure how to calculate Favail
 		Flag:    uint64(stat.Flags),
 		Namemax: 255, // we use a conservative value here
 	}, nil


### PR DESCRIPTION
I noticed that the `golangci-lint` step was failing on `main`, ran it locally, and have fixed a few things it was raising:
```
❯ golangci-lint run
httpd/httpd_test.go:121:2: `robotsTxtPath` is unused (deadcode)
	robotsTxtPath                   = "/robots.txt"
	^
vfs/statvfs_unix.go:22:18: unnecessary conversion (unconvert)
		Bavail:  uint64(stat.Bavail),
		               ^
vfs/statvfs_unix.go:24:18: unnecessary conversion (unconvert)
		Ffree:   uint64(stat.Ffree),
		               ^
vfs/statvfs_unix.go:25:18: unnecessary conversion (unconvert)
		Favail:  uint64(stat.Ffree), // not sure how to calculate Favail
		               ^
```

Also made use of the existing `healtzPath` value in `TestHealthCheck` for consistency with other tests using the value. 