### PR TITLE
feat: make MFA status visible in WebAdmin

### DIFF
--- a/dataprovider/user.go
+++ b/dataprovider/user.go
@@ -1331,6 +1331,15 @@ func (u *User) GetBandwidthAsString() string {
 	return result
 }
 
+// GetMFAStatusAsString returns MFA status
+func (u *User) GetMFAStatusAsString() string {
+	result := "-"
+	if u.Filters.TOTPConfig.Enabled {
+		result = strings.Join(u.Filters.TOTPConfig.Protocols, ", ")
+	}
+	return result
+}
+
 // GetInfoString returns user's info as string.
 // Storage provider, number of public keys, max sessions, uid,
 // gid, denied and allowed IP/Mask are returned

--- a/httpd/webadmin.go
+++ b/httpd/webadmin.go
@@ -130,6 +130,7 @@ type basePage struct {
 	CSRFToken          string
 	HasDefender        bool
 	HasExternalLogin   bool
+	HasMFA             bool
 	LoggedAdmin        *dataprovider.Admin
 	Branding           UIBranding
 }
@@ -485,6 +486,7 @@ func (s *httpdServer) getBasePageData(title, currentURL string, r *http.Request)
 		Version:            version.GetAsString(),
 		LoggedAdmin:        getAdminFromToken(r),
 		HasDefender:        common.Config.DefenderConfig.Enabled,
+		HasMFA:             len(mfa.GetAvailableTOTPConfigNames()) > 0,
 		HasExternalLogin:   isLoggedInWithOIDC(r),
 		CSRFToken:          csrfToken,
 		Branding:           s.binding.Branding.WebAdmin,

--- a/templates/webadmin/admins.html
+++ b/templates/webadmin/admins.html
@@ -32,6 +32,7 @@
                         <th>ID</th>
                         <th>Username</th>
                         <th>Status</th>
+                        <th>MFA</th>
                         <th>Permissions</th>
                         <th>Other</th>
                     </tr>
@@ -42,6 +43,7 @@
                         <td>{{.ID}}</td>
                         <td>{{.Username}}</td>
                         <td>{{if eq .Status 1 }}Active{{else}}Inactive{{end}}</td>
+                        <td>{{if .Filters.TOTPConfig.Enabled }}Enabled{{else}}-{{end}}</td>
                         <td>{{.GetPermissionsAsString}}</td>
                         <td>{{.GetInfoString}}</td>
                     </tr>

--- a/templates/webadmin/admins.html
+++ b/templates/webadmin/admins.html
@@ -32,7 +32,7 @@
                         <th>ID</th>
                         <th>Username</th>
                         <th>Status</th>
-                        <th>MFA</th>
+                        {{if .HasMFA }}<th>MFA</th>{{end}}
                         <th>Permissions</th>
                         <th>Other</th>
                     </tr>
@@ -43,7 +43,7 @@
                         <td>{{.ID}}</td>
                         <td>{{.Username}}</td>
                         <td>{{if eq .Status 1 }}Active{{else}}Inactive{{end}}</td>
-                        <td>{{if .Filters.TOTPConfig.Enabled }}Enabled{{else}}-{{end}}</td>
+                        {{if $.HasMFA }}<td>{{if .Filters.TOTPConfig.Enabled }}Enabled{{else}}-{{end}}</td>{{end}}
                         <td>{{.GetPermissionsAsString}}</td>
                         <td>{{.GetInfoString}}</td>
                     </tr>

--- a/templates/webadmin/users.html
+++ b/templates/webadmin/users.html
@@ -32,6 +32,7 @@
                         <th>ID</th>
                         <th>Username</th>
                         <th>Status</th>
+                        <th>MFA</th>
                         <th>Bandwidth</th>
                         <th>Quota</th>
                         <th>Other</th>
@@ -43,6 +44,7 @@
                         <td>{{.ID}}</td>
                         <td>{{.Username}}</td>
                         <td>{{.GetStatusAsString}}</td>
+                        <td>{{if .Filters.TOTPConfig.Enabled }}Enabled{{else}}-{{end}}</td>
                         <td>{{.GetBandwidthAsString}}</td>
                         <td>{{.GetQuotaSummary}}</td>
                         <td>{{.GetInfoString}}</td>

--- a/templates/webadmin/users.html
+++ b/templates/webadmin/users.html
@@ -32,7 +32,7 @@
                         <th>ID</th>
                         <th>Username</th>
                         <th>Status</th>
-                        <th>MFA</th>
+                        {{if .HasMFA }}<th>MFA</th>{{end}}
                         <th>Bandwidth</th>
                         <th>Quota</th>
                         <th>Other</th>
@@ -44,7 +44,7 @@
                         <td>{{.ID}}</td>
                         <td>{{.Username}}</td>
                         <td>{{.GetStatusAsString}}</td>
-                        <td>{{.GetMFAStatusAsString}}</td>
+                        {{if $.HasMFA }}<td>{{.GetMFAStatusAsString}}</td>{{end}}
                         <td>{{.GetBandwidthAsString}}</td>
                         <td>{{.GetQuotaSummary}}</td>
                         <td>{{.GetInfoString}}</td>

--- a/templates/webadmin/users.html
+++ b/templates/webadmin/users.html
@@ -44,7 +44,7 @@
                         <td>{{.ID}}</td>
                         <td>{{.Username}}</td>
                         <td>{{.GetStatusAsString}}</td>
-                        <td>{{if .Filters.TOTPConfig.Enabled }}Enabled{{else}}-{{end}}</td>
+                        <td>{{.GetMFAStatusAsString}}</td>
                         <td>{{.GetBandwidthAsString}}</td>
                         <td>{{.GetQuotaSummary}}</td>
                         <td>{{.GetInfoString}}</td>


### PR DESCRIPTION
Hi 👋 

Sometimes it's nice to have visibility into MFA status of admins and users.

Admins:
<img width="1191" alt="Screenshot 2022-05-17 at 3 05 18 PM" src="https://user-images.githubusercontent.com/57101177/168831505-964bb457-3396-4ee0-a884-078a6bc23d2f.png">

Users:
<img width="1327" alt="Screenshot 2022-05-17 at 3 08 36 PM" src="https://user-images.githubusercontent.com/57101177/168831561-b4ee0d5d-8057-4f66-bcfb-9f38a7c33d32.png">

@drakkan - currently, users show as either `Enabled` or `-`. Do you think it might be better to show what protocols MFA is enabled for each user? 🤔
