### PR TITLE
OIDC: Allow Scope to be configured

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -1370,6 +1370,12 @@ func getHTTPDOIDCFromEnv(idx int) (httpd.OIDC, bool) {
 		isSet = true
 	}
 
+	scopes, ok := lookupStringListFromEnv(fmt.Sprintf("SFTPGO_HTTPD__BINDINGS__%v__OIDC__SCOPES", idx))
+	if ok {
+		result.Scopes = scopes
+		isSet = true
+	}
+
 	roleField, ok := os.LookupEnv(fmt.Sprintf("SFTPGO_HTTPD__BINDINGS__%v__OIDC__ROLE_FIELD", idx))
 	if ok {
 		result.RoleField = roleField

--- a/docs/full-configuration.md
+++ b/docs/full-configuration.md
@@ -279,6 +279,7 @@ The configuration file contains the following sections:
       - `client_secret`, string. Defines the application's secret. Default: blank.
       - `redirect_base_url`, string. Defines the base URL to redirect to after OpenID authentication. The suffix `/web/oidc/redirect` will be added to this base URL, adding also the `web_root` if configured. Default: blank.
       - `username_field`, string. Defines the ID token claims field to map to the SFTPGo username. Default: blank.
+      - `scopes`, list of strings. Request the OAuth provider to provide the scope information from an authenticated users. Default: `"openid", "profile", "email"`.
       - `role_field`, string. Defines the optional ID token claims field to map to a SFTPGo role. If the defined ID token claims field is set to `admin` the authenticated user is mapped to an SFTPGo admin. You don't need to specify this field if you want to use OpenID only for the Web Client UI. Default: blank.
       - `implicit_roles`, boolean. If set, the `role_field` is ignored and the SFTPGo role is assumed based on the login link used. Default: `false`.
       - `custom_fields`, list of strings. Custom token claims fields to pass to the pre-login hook. Default: empty.

--- a/docs/oidc.md
+++ b/docs/oidc.md
@@ -1,6 +1,7 @@
 # OpenID Connect
 
-OpenID Connect integration allows you to map your identity provider users to SFTPGo admins/users and so you can login to SFTPGo Web Client and Web Admin user interfaces using your identity provider.
+OpenID Connect integration allows you to map your identity provider users to SFTPGo admins/users,
+so you can login to SFTPGo Web Client and Web Admin user interfaces, using your own identity provider.
 
 SFTPGo allows to configure per-binding OpenID Connect configurations. The supported configuration parameters are documented within the `oidc` section [here](./full-configuration.md).
 
@@ -42,6 +43,7 @@ Add the following configuration parameters to the SFTPGo configuration file (or 
       "config_url": "http://192.168.1.12:8086/auth/realms/sftpgo",
       "redirect_base_url": "http://192.168.1.50:8080",
       "username_field": "preferred_username",
+      "scopes": [ "openid", "profile", "email" ],
       "role_field": "sftpgo_role",
       "implicit_roles": false,
       "custom_fields": []
@@ -104,8 +106,12 @@ And the following is an example ID token which allows the SFTPGo user `user1` to
 ```
 
 SFTPGo users (not admins) can be created/updated after successful OpenID authentication by defining a [pre-login hook](./dynamic-user-mod.md).
-You can use the `custom_fields` configuration parameter to define the token claims field names to pass to the pre-login hook, these fields are useful for implementing custom logic when creating/updating the SFTPGo user within the hook.
-For example you can set the field `sftpgo_home_dir` in your identity provider and add it to the `custom_fields` in the SFTPGo configuration like this:
+You can use `scopes` configuration to request additional information (claims) about authenticated users (See your provider's own documentation for more information).
+By default the scopes `"openid", "profile", "email"` are retrieved.
+The `custom_fields` configuration parameter can be used to define claim field names to pass to the pre-login hook,
+these fields can be used e.g. for implementing custom logic when creating/updating the SFTPGo user within the hook.
+For example, if you have created a scope with name `sftpgo` in your identity provider to provide a claim for `sftpgo_home_dir` ,
+then you can add it to the `custom_fields` in the SFTPGo configuration like this:
 
 ```json
 ...
@@ -115,6 +121,7 @@ For example you can set the field `sftpgo_home_dir` in your identity provider an
       "config_url": "http://192.168.1.12:8086/auth/realms/sftpgo",
       "redirect_base_url": "http://192.168.1.50:8080",
       "username_field": "preferred_username",
+      "scopes": [ "openid", "profile", "email", "sftpgo" ],
       "role_field": "sftpgo_role",
       "custom_fields": ["sftpgo_home_dir"]
     }

--- a/httpd/oidc.go
+++ b/httpd/oidc.go
@@ -70,6 +70,8 @@ type OIDC struct {
 	// If set, the `RoleField` is ignored and the SFTPGo role is assumed based on
 	// the login link used
 	ImplicitRoles bool `json:"implicit_roles" mapstructure:"implicit_roles"`
+	// Scopes required by the OAuth provider to retrieve information about the authenticated user. Refer to your OAuth provider documentation for more information about this
+	Scopes []string `json:"scopes" mapstructure:"scopes"`
 	// Custom token claims fields to pass to the pre-login hook
 	CustomFields      []string `json:"custom_fields" mapstructure:"custom_fields"`
 	provider          *oidc.Provider
@@ -143,7 +145,7 @@ func (o *OIDC) initialize() error {
 		ClientSecret: o.ClientSecret,
 		Endpoint:     o.provider.Endpoint(),
 		RedirectURL:  o.getRedirectURL(),
-		Scopes:       []string{oidc.ScopeOpenID, "profile", "email"},
+		Scopes:       o.Scopes,
 	}
 
 	return nil

--- a/sftpgo.json
+++ b/sftpgo.json
@@ -262,6 +262,7 @@
           "client_secret": "",
           "config_url": "",
           "redirect_base_url": "",
+          "scopes": [ "openid", "profile", "email" ],
           "username_field": "",
           "role_field": "",
           "implicit_roles": false,


### PR DESCRIPTION
In order to request additional information for user creation the OAuth scopes should be configurable and not hardcoded.

Otherwise the existing (default) scopes needs to be extended which would provide the information to other OAuth apps requesting the scope as well. This is not intended.

Please let me know if I missed something.