### PR TITLE
Added charset=utf-8 to application/json content type

### DIFF
--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -126,7 +126,7 @@ paths:
         '201':
           description: successful operation
           content:
-            application/json:
+            application/json; charset=utf-8:
               schema:
                 type: array
                 items:
@@ -223,7 +223,7 @@ paths:
         '200':
           description: successful operation
           content:
-            application/json:
+            application/json; charset=utf-8:
               schema:
                 type: array
                 items:
@@ -292,7 +292,7 @@ paths:
         '201':
           description: successful operation
           content:
-            application/json:
+            application/json; charset=utf-8:
               schema:
                 type: array
                 items:
@@ -329,7 +329,7 @@ paths:
         '200':
           description: successful operation
           content:
-            application/json:
+            application/json; charset=utf-8:
               schema:
                 $ref: '#/components/schemas/Token'
         '401':
@@ -353,7 +353,7 @@ paths:
         '200':
           description: successful operation
           content:
-            application/json:
+            application/json; charset=utf-8:
               schema:
                 $ref: '#/components/schemas/ApiResponse'
         '401':
@@ -384,7 +384,7 @@ paths:
         '200':
           description: successful operation
           content:
-            application/json:
+            application/json; charset=utf-8:
               schema:
                 $ref: '#/components/schemas/Token'
         '401':
@@ -408,7 +408,7 @@ paths:
         '200':
           description: successful operation
           content:
-            application/json:
+            application/json; charset=utf-8:
               schema:
                 $ref: '#/components/schemas/ApiResponse'
         '401':
@@ -430,7 +430,7 @@ paths:
         '200':
           description: successful operation
           content:
-            application/json:
+            application/json; charset=utf-8:
               schema:
                 $ref: '#/components/schemas/VersionInfo'
         '401':
@@ -453,14 +453,14 @@ paths:
       requestBody:
         required: true
         content:
-          application/json:
+          application/json; charset=utf-8:
             schema:
               $ref: '#/components/schemas/PwdChange'
       responses:
         '200':
           description: successful operation
           content:
-            application/json:
+            application/json; charset=utf-8:
               schema:
                 $ref: '#/components/schemas/ApiResponse'
         '401':
@@ -484,7 +484,7 @@ paths:
         '200':
           description: successful operation
           content:
-            application/json:
+            application/json; charset=utf-8:
               schema:
                 $ref: '#/components/schemas/AdminProfile'
         '401':
@@ -506,14 +506,14 @@ paths:
       requestBody:
         required: true
         content:
-          application/json:
+          application/json; charset=utf-8:
             schema:
               $ref: '#/components/schemas/AdminProfile'
       responses:
         '200':
           description: successful operation
           content:
-            application/json:
+            application/json; charset=utf-8:
               schema:
                 $ref: '#/components/schemas/ApiResponse'
         '400':
@@ -539,7 +539,7 @@ paths:
         '200':
           description: successful operation
           content:
-            application/json:
+            application/json; charset=utf-8:
               schema:
                 type: array
                 items:
@@ -564,7 +564,7 @@ paths:
         '200':
           description: successful operation
           content:
-            application/json:
+            application/json; charset=utf-8:
               schema:
                 type: array
                 items:
@@ -592,7 +592,7 @@ paths:
         '200':
           description: successful operation
           content:
-            application/json:
+            application/json; charset=utf-8:
               schema:
                 type: array
                 items:
@@ -617,7 +617,7 @@ paths:
       requestBody:
         required: true
         content:
-          application/json:
+          application/json; charset=utf-8:
             schema:
               type: object
               properties:
@@ -628,7 +628,7 @@ paths:
         '200':
           description: successful operation
           content:
-            application/json:
+            application/json; charset=utf-8:
               schema:
                 type: object
                 properties:
@@ -664,7 +664,7 @@ paths:
       requestBody:
         required: true
         content:
-          application/json:
+          application/json; charset=utf-8:
             schema:
               type: object
               properties:
@@ -681,7 +681,7 @@ paths:
         '200':
           description: successful operation
           content:
-            application/json:
+            application/json; charset=utf-8:
               schema:
                 $ref: '#/components/schemas/ApiResponse'
               example:
@@ -708,14 +708,14 @@ paths:
       requestBody:
         required: true
         content:
-          application/json:
+          application/json; charset=utf-8:
             schema:
               $ref: '#/components/schemas/AdminTOTPConfig'
       responses:
         '200':
           description: successful operation
           content:
-            application/json:
+            application/json; charset=utf-8:
               schema:
                 $ref: '#/components/schemas/ApiResponse'
               example:
@@ -741,7 +741,7 @@ paths:
         '200':
           description: successful operation
           content:
-            application/json:
+            application/json; charset=utf-8:
               schema:
                 type: array
                 items:
@@ -772,7 +772,7 @@ paths:
         '200':
           description: successful operation
           content:
-            application/json:
+            application/json; charset=utf-8:
               schema:
                 $ref: '#/components/schemas/ApiResponse'
               example:
@@ -798,7 +798,7 @@ paths:
         '200':
           description: successful operation
           content:
-            application/json:
+            application/json; charset=utf-8:
               schema:
                 type: array
                 items:
@@ -831,7 +831,7 @@ paths:
         '200':
           description: successful operation
           content:
-            application/json:
+            application/json; charset=utf-8:
               schema:
                 $ref: '#/components/schemas/DefenderEntry'
         '401':
@@ -854,7 +854,7 @@ paths:
         '200':
           description: successful operation
           content:
-            application/json:
+            application/json; charset=utf-8:
               schema:
                 $ref: '#/components/schemas/ApiResponse'
         '401':
@@ -878,7 +878,7 @@ paths:
         '200':
           description: successful operation
           content:
-            application/json:
+            application/json; charset=utf-8:
               schema:
                 type: array
                 items:
@@ -909,7 +909,7 @@ paths:
         '202':
           description: successful operation
           content:
-            application/json:
+            application/json; charset=utf-8:
               schema:
                 $ref: '#/components/schemas/ApiResponse'
               example:
@@ -939,7 +939,7 @@ paths:
         '200':
           description: successful operation
           content:
-            application/json:
+            application/json; charset=utf-8:
               schema:
                 type: array
                 items:
@@ -978,7 +978,7 @@ paths:
         required: true
         description: 'Defines virtual paths to check and their retention time in hours'
         content:
-          application/json:
+          application/json; charset=utf-8:
             schema:
               type: array
               items:
@@ -987,7 +987,7 @@ paths:
         '202':
           description: successful operation
           content:
-            application/json:
+            application/json; charset=utf-8:
               schema:
                 $ref: '#/components/schemas/ApiResponse'
               example:
@@ -1017,7 +1017,7 @@ paths:
         '200':
           description: successful operation
           content:
-            application/json:
+            application/json; charset=utf-8:
               schema:
                 type: array
                 items:
@@ -1048,7 +1048,7 @@ paths:
         '202':
           description: successful operation
           content:
-            application/json:
+            application/json; charset=utf-8:
               schema:
                 $ref: '#/components/schemas/ApiResponse'
               example:
@@ -1099,14 +1099,14 @@ paths:
         required: true
         description: 'If used_quota_size and used_quota_files are missing they will default to 0, this means that if mode is "add" the current value, for the missing field, will remain unchanged, if mode is "reset" the missing field is set to 0'
         content:
-          application/json:
+          application/json; charset=utf-8:
             schema:
               $ref: '#/components/schemas/QuotaUsage'
       responses:
         '200':
           description: successful operation
           content:
-            application/json:
+            application/json; charset=utf-8:
               schema:
                 $ref: '#/components/schemas/ApiResponse'
               example:
@@ -1157,14 +1157,14 @@ paths:
         required: true
         description: 'If used_upload_data_transfer and used_download_data_transfer are missing they will default to 0, this means that if mode is "add" the current value, for the missing field, will remain unchanged, if mode is "reset" the missing field is set to 0'
         content:
-          application/json:
+          application/json; charset=utf-8:
             schema:
               $ref: '#/components/schemas/TransferQuotaUsage'
       responses:
         '200':
           description: successful operation
           content:
-            application/json:
+            application/json; charset=utf-8:
               schema:
                 $ref: '#/components/schemas/ApiResponse'
               example:
@@ -1194,7 +1194,7 @@ paths:
         '200':
           description: successful operation
           content:
-            application/json:
+            application/json; charset=utf-8:
               schema:
                 type: array
                 items:
@@ -1225,7 +1225,7 @@ paths:
         '202':
           description: successful operation
           content:
-            application/json:
+            application/json; charset=utf-8:
               schema:
                 $ref: '#/components/schemas/ApiResponse'
               example:
@@ -1291,14 +1291,14 @@ paths:
         required: true
         description: 'If used_quota_size and used_quota_files are missing they will default to 0, this means that if mode is "add" the current value, for the missing field, will remain unchanged, if mode is "reset" the missing field is set to 0'
         content:
-          application/json:
+          application/json; charset=utf-8:
             schema:
               $ref: '#/components/schemas/QuotaUsage'
       responses:
         '200':
           description: successful operation
           content:
-            application/json:
+            application/json; charset=utf-8:
               schema:
                 $ref: '#/components/schemas/ApiResponse'
               example:
@@ -1355,7 +1355,7 @@ paths:
         '200':
           description: successful operation
           content:
-            application/json:
+            application/json; charset=utf-8:
               schema:
                 type: array
                 items:
@@ -1379,14 +1379,14 @@ paths:
       requestBody:
         required: true
         content:
-          application/json:
+          application/json; charset=utf-8:
             schema:
               $ref: '#/components/schemas/BaseVirtualFolder'
       responses:
         '201':
           description: successful operation
           content:
-            application/json:
+            application/json; charset=utf-8:
               schema:
                 $ref: '#/components/schemas/BaseVirtualFolder'
         '400':
@@ -1417,7 +1417,7 @@ paths:
         '200':
           description: successful operation
           content:
-            application/json:
+            application/json; charset=utf-8:
               schema:
                 $ref: '#/components/schemas/BaseVirtualFolder'
         '400':
@@ -1441,14 +1441,14 @@ paths:
       requestBody:
         required: true
         content:
-          application/json:
+          application/json; charset=utf-8:
             schema:
               $ref: '#/components/schemas/BaseVirtualFolder'
       responses:
         '200':
           description: successful operation
           content:
-            application/json:
+            application/json; charset=utf-8:
               schema:
                 $ref: '#/components/schemas/ApiResponse'
               example:
@@ -1475,7 +1475,7 @@ paths:
         '200':
           description: successful operation
           content:
-            application/json:
+            application/json; charset=utf-8:
               schema:
                 $ref: '#/components/schemas/ApiResponse'
               example:
@@ -1530,7 +1530,7 @@ paths:
         '200':
           description: successful operation
           content:
-            application/json:
+            application/json; charset=utf-8:
               schema:
                 type: array
                 items:
@@ -1554,14 +1554,14 @@ paths:
       requestBody:
         required: true
         content:
-          application/json:
+          application/json; charset=utf-8:
             schema:
               $ref: '#/components/schemas/Group'
       responses:
         '201':
           description: successful operation
           content:
-            application/json:
+            application/json; charset=utf-8:
               schema:
                 $ref: '#/components/schemas/Group'
         '400':
@@ -1592,7 +1592,7 @@ paths:
         '200':
           description: successful operation
           content:
-            application/json:
+            application/json; charset=utf-8:
               schema:
                 $ref: '#/components/schemas/Group'
         '400':
@@ -1616,14 +1616,14 @@ paths:
       requestBody:
         required: true
         content:
-          application/json:
+          application/json; charset=utf-8:
             schema:
               $ref: '#/components/schemas/Group'
       responses:
         '200':
           description: successful operation
           content:
-            application/json:
+            application/json; charset=utf-8:
               schema:
                 $ref: '#/components/schemas/ApiResponse'
               example:
@@ -1650,7 +1650,7 @@ paths:
         '200':
           description: successful operation
           content:
-            application/json:
+            application/json; charset=utf-8:
               schema:
                 $ref: '#/components/schemas/ApiResponse'
               example:
@@ -1705,7 +1705,7 @@ paths:
         '200':
           description: successful operation
           content:
-            application/json:
+            application/json; charset=utf-8:
               schema:
                 type: array
                 items:
@@ -1729,14 +1729,14 @@ paths:
       requestBody:
         required: true
         content:
-          application/json:
+          application/json; charset=utf-8:
             schema:
               $ref: '#/components/schemas/Role'
       responses:
         '201':
           description: successful operation
           content:
-            application/json:
+            application/json; charset=utf-8:
               schema:
                 $ref: '#/components/schemas/Role'
         '400':
@@ -1767,7 +1767,7 @@ paths:
         '200':
           description: successful operation
           content:
-            application/json:
+            application/json; charset=utf-8:
               schema:
                 $ref: '#/components/schemas/Role'
         '400':
@@ -1791,14 +1791,14 @@ paths:
       requestBody:
         required: true
         content:
-          application/json:
+          application/json; charset=utf-8:
             schema:
               $ref: '#/components/schemas/Role'
       responses:
         '200':
           description: successful operation
           content:
-            application/json:
+            application/json; charset=utf-8:
               schema:
                 $ref: '#/components/schemas/ApiResponse'
               example:
@@ -1825,7 +1825,7 @@ paths:
         '200':
           description: successful operation
           content:
-            application/json:
+            application/json; charset=utf-8:
               schema:
                 $ref: '#/components/schemas/ApiResponse'
               example:
@@ -1880,7 +1880,7 @@ paths:
         '200':
           description: successful operation
           content:
-            application/json:
+            application/json; charset=utf-8:
               schema:
                 type: array
                 items:
@@ -1904,14 +1904,14 @@ paths:
       requestBody:
         required: true
         content:
-          application/json:
+          application/json; charset=utf-8:
             schema:
               $ref: '#/components/schemas/BaseEventAction'
       responses:
         '201':
           description: successful operation
           content:
-            application/json:
+            application/json; charset=utf-8:
               schema:
                 $ref: '#/components/schemas/BaseEventAction'
         '400':
@@ -1942,7 +1942,7 @@ paths:
         '200':
           description: successful operation
           content:
-            application/json:
+            application/json; charset=utf-8:
               schema:
                 $ref: '#/components/schemas/BaseEventAction'
         '400':
@@ -1966,14 +1966,14 @@ paths:
       requestBody:
         required: true
         content:
-          application/json:
+          application/json; charset=utf-8:
             schema:
               $ref: '#/components/schemas/BaseEventAction'
       responses:
         '200':
           description: successful operation
           content:
-            application/json:
+            application/json; charset=utf-8:
               schema:
                 $ref: '#/components/schemas/ApiResponse'
               example:
@@ -2000,7 +2000,7 @@ paths:
         '200':
           description: successful operation
           content:
-            application/json:
+            application/json; charset=utf-8:
               schema:
                 $ref: '#/components/schemas/ApiResponse'
               example:
@@ -2055,7 +2055,7 @@ paths:
         '200':
           description: successful operation
           content:
-            application/json:
+            application/json; charset=utf-8:
               schema:
                 type: array
                 items:
@@ -2079,14 +2079,14 @@ paths:
       requestBody:
         required: true
         content:
-          application/json:
+          application/json; charset=utf-8:
             schema:
               $ref: '#/components/schemas/EventRuleMinimal'
       responses:
         '201':
           description: successful operation
           content:
-            application/json:
+            application/json; charset=utf-8:
               schema:
                 $ref: '#/components/schemas/EventRule'
         '400':
@@ -2117,7 +2117,7 @@ paths:
         '200':
           description: successful operation
           content:
-            application/json:
+            application/json; charset=utf-8:
               schema:
                 $ref: '#/components/schemas/EventRule'
         '400':
@@ -2141,14 +2141,14 @@ paths:
       requestBody:
         required: true
         content:
-          application/json:
+          application/json; charset=utf-8:
             schema:
               $ref: '#/components/schemas/EventRuleMinimal'
       responses:
         '200':
           description: successful operation
           content:
-            application/json:
+            application/json; charset=utf-8:
               schema:
                 $ref: '#/components/schemas/ApiResponse'
               example:
@@ -2175,7 +2175,7 @@ paths:
         '200':
           description: successful operation
           content:
-            application/json:
+            application/json; charset=utf-8:
               schema:
                 $ref: '#/components/schemas/ApiResponse'
               example:
@@ -2335,7 +2335,7 @@ paths:
         '200':
           description: successful operation
           content:
-            application/json:
+            application/json; charset=utf-8:
               schema:
                 type: array
                 items:
@@ -2476,7 +2476,7 @@ paths:
         '200':
           description: successful operation
           content:
-            application/json:
+            application/json; charset=utf-8:
               schema:
                 type: array
                 items:
@@ -2534,7 +2534,7 @@ paths:
         '200':
           description: successful operation
           content:
-            application/json:
+            application/json; charset=utf-8:
               schema:
                 type: array
                 items:
@@ -2560,7 +2560,7 @@ paths:
       requestBody:
         required: true
         content:
-          application/json:
+          application/json; charset=utf-8:
             schema:
               $ref: '#/components/schemas/APIKey'
       responses:
@@ -2576,7 +2576,7 @@ paths:
                 type: string
               description: URL to retrieve the details for the new created API key
           content:
-            application/json:
+            application/json; charset=utf-8:
               schema:
                 type: object
                 properties:
@@ -2616,7 +2616,7 @@ paths:
         '200':
           description: successful operation
           content:
-            application/json:
+            application/json; charset=utf-8:
               schema:
                 $ref: '#/components/schemas/APIKey'
         '400':
@@ -2642,14 +2642,14 @@ paths:
       requestBody:
         required: true
         content:
-          application/json:
+          application/json; charset=utf-8:
             schema:
               $ref: '#/components/schemas/APIKey'
       responses:
         '200':
           description: successful operation
           content:
-            application/json:
+            application/json; charset=utf-8:
               schema:
                 $ref: '#/components/schemas/ApiResponse'
               example:
@@ -2678,7 +2678,7 @@ paths:
         '200':
           description: successful operation
           content:
-            application/json:
+            application/json; charset=utf-8:
               schema:
                 $ref: '#/components/schemas/ApiResponse'
               example:
@@ -2733,7 +2733,7 @@ paths:
         '200':
           description: successful operation
           content:
-            application/json:
+            application/json; charset=utf-8:
               schema:
                 type: array
                 items:
@@ -2757,14 +2757,14 @@ paths:
       requestBody:
         required: true
         content:
-          application/json:
+          application/json; charset=utf-8:
             schema:
               $ref: '#/components/schemas/Admin'
       responses:
         '201':
           description: successful operation
           content:
-            application/json:
+            application/json; charset=utf-8:
               schema:
                 $ref: '#/components/schemas/Admin'
         '400':
@@ -2795,7 +2795,7 @@ paths:
         '200':
           description: successful operation
           content:
-            application/json:
+            application/json; charset=utf-8:
               schema:
                 $ref: '#/components/schemas/Admin'
         '400':
@@ -2819,14 +2819,14 @@ paths:
       requestBody:
         required: true
         content:
-          application/json:
+          application/json; charset=utf-8:
             schema:
               $ref: '#/components/schemas/Admin'
       responses:
         '200':
           description: successful operation
           content:
-            application/json:
+            application/json; charset=utf-8:
               schema:
                 $ref: '#/components/schemas/ApiResponse'
               example:
@@ -2853,7 +2853,7 @@ paths:
         '200':
           description: successful operation
           content:
-            application/json:
+            application/json; charset=utf-8:
               schema:
                 $ref: '#/components/schemas/ApiResponse'
               example:
@@ -2888,7 +2888,7 @@ paths:
         '200':
           description: successful operation
           content:
-            application/json:
+            application/json; charset=utf-8:
               schema:
                 $ref: '#/components/schemas/ApiResponse'
               example:
@@ -2924,7 +2924,7 @@ paths:
         '200':
           description: successful operation
           content:
-            application/json:
+            application/json; charset=utf-8:
               schema:
                 $ref: '#/components/schemas/ApiResponse'
         '400':
@@ -2956,7 +2956,7 @@ paths:
       operationId: admin_reset_password
       requestBody:
         content:
-          application/json:
+          application/json; charset=utf-8:
             schema:
               type: object
               properties:
@@ -2969,7 +2969,7 @@ paths:
         '200':
           description: successful operation
           content:
-            application/json:
+            application/json; charset=utf-8:
               schema:
                 $ref: '#/components/schemas/ApiResponse'
         '400':
@@ -3022,7 +3022,7 @@ paths:
         '200':
           description: successful operation
           content:
-            application/json:
+            application/json; charset=utf-8:
               schema:
                 type: array
                 items:
@@ -3046,14 +3046,14 @@ paths:
       requestBody:
         required: true
         content:
-          application/json:
+          application/json; charset=utf-8:
             schema:
               $ref: '#/components/schemas/User'
       responses:
         '201':
           description: successful operation
           content:
-            application/json:
+            application/json; charset=utf-8:
               schema:
                 $ref: '#/components/schemas/User'
         '400':
@@ -3084,7 +3084,7 @@ paths:
         '200':
           description: successful operation
           content:
-            application/json:
+            application/json; charset=utf-8:
               schema:
                 $ref: '#/components/schemas/User'
         '400':
@@ -3120,14 +3120,14 @@ paths:
       requestBody:
         required: true
         content:
-          application/json:
+          application/json; charset=utf-8:
             schema:
               $ref: '#/components/schemas/User'
       responses:
         '200':
           description: successful operation
           content:
-            application/json:
+            application/json; charset=utf-8:
               schema:
                 $ref: '#/components/schemas/ApiResponse'
               example:
@@ -3154,7 +3154,7 @@ paths:
         '200':
           description: successful operation
           content:
-            application/json:
+            application/json; charset=utf-8:
               schema:
                 $ref: '#/components/schemas/ApiResponse'
               example:
@@ -3189,7 +3189,7 @@ paths:
         '200':
           description: successful operation
           content:
-            application/json:
+            application/json; charset=utf-8:
               schema:
                 $ref: '#/components/schemas/ApiResponse'
               example:
@@ -3225,7 +3225,7 @@ paths:
         '200':
           description: successful operation
           content:
-            application/json:
+            application/json; charset=utf-8:
               schema:
                 $ref: '#/components/schemas/ApiResponse'
         '400':
@@ -3257,7 +3257,7 @@ paths:
       operationId: user_reset_password
       requestBody:
         content:
-          application/json:
+          application/json; charset=utf-8:
             schema:
               type: object
               properties:
@@ -3270,7 +3270,7 @@ paths:
         '200':
           description: successful operation
           content:
-            application/json:
+            application/json; charset=utf-8:
               schema:
                 $ref: '#/components/schemas/ApiResponse'
         '400':
@@ -3296,7 +3296,7 @@ paths:
         '200':
           description: successful operation
           content:
-            application/json:
+            application/json; charset=utf-8:
               schema:
                 $ref: '#/components/schemas/ServicesStatus'
         '400':
@@ -3348,7 +3348,7 @@ paths:
         '200':
           description: successful operation
           content:
-            application/json:
+            application/json; charset=utf-8:
               schema:
                 oneOf:
                   - $ref: '#/components/schemas/ApiResponse'
@@ -3409,7 +3409,7 @@ paths:
         '200':
           description: successful operation
           content:
-            application/json:
+            application/json; charset=utf-8:
               schema:
                 $ref: '#/components/schemas/ApiResponse'
               example:
@@ -3433,14 +3433,14 @@ paths:
       requestBody:
         required: true
         content:
-          application/json:
+          application/json; charset=utf-8:
             schema:
               $ref: '#/components/schemas/BackupData'
       responses:
         '200':
           description: successful operation
           content:
-            application/json:
+            application/json; charset=utf-8:
               schema:
                 $ref: '#/components/schemas/ApiResponse'
               example:
@@ -3467,14 +3467,14 @@ paths:
       requestBody:
         required: true
         content:
-          application/json:
+          application/json; charset=utf-8:
             schema:
               $ref: '#/components/schemas/PwdChange'
       responses:
         '200':
           description: successful operation
           content:
-            application/json:
+            application/json; charset=utf-8:
               schema:
                 $ref: '#/components/schemas/ApiResponse'
         '401':
@@ -3498,7 +3498,7 @@ paths:
         '200':
           description: successful operation
           content:
-            application/json:
+            application/json; charset=utf-8:
               schema:
                 $ref: '#/components/schemas/UserProfile'
         '401':
@@ -3520,14 +3520,14 @@ paths:
       requestBody:
         required: true
         content:
-          application/json:
+          application/json; charset=utf-8:
             schema:
               $ref: '#/components/schemas/UserProfile'
       responses:
         '200':
           description: successful operation
           content:
-            application/json:
+            application/json; charset=utf-8:
               schema:
                 $ref: '#/components/schemas/ApiResponse'
         '400':
@@ -3553,7 +3553,7 @@ paths:
         '200':
           description: successful operation
           content:
-            application/json:
+            application/json; charset=utf-8:
               schema:
                 type: array
                 items:
@@ -3578,7 +3578,7 @@ paths:
         '200':
           description: successful operation
           content:
-            application/json:
+            application/json; charset=utf-8:
               schema:
                 type: array
                 items:
@@ -3606,7 +3606,7 @@ paths:
         '200':
           description: successful operation
           content:
-            application/json:
+            application/json; charset=utf-8:
               schema:
                 type: array
                 items:
@@ -3631,7 +3631,7 @@ paths:
       requestBody:
         required: true
         content:
-          application/json:
+          application/json; charset=utf-8:
             schema:
               type: object
               properties:
@@ -3642,7 +3642,7 @@ paths:
         '200':
           description: successful operation
           content:
-            application/json:
+            application/json; charset=utf-8:
               schema:
                 type: object
                 properties:
@@ -3678,7 +3678,7 @@ paths:
       requestBody:
         required: true
         content:
-          application/json:
+          application/json; charset=utf-8:
             schema:
               type: object
               properties:
@@ -3695,7 +3695,7 @@ paths:
         '200':
           description: successful operation
           content:
-            application/json:
+            application/json; charset=utf-8:
               schema:
                 $ref: '#/components/schemas/ApiResponse'
               example:
@@ -3722,14 +3722,14 @@ paths:
       requestBody:
         required: true
         content:
-          application/json:
+          application/json; charset=utf-8:
             schema:
               $ref: '#/components/schemas/UserTOTPConfig'
       responses:
         '200':
           description: successful operation
           content:
-            application/json:
+            application/json; charset=utf-8:
               schema:
                 $ref: '#/components/schemas/ApiResponse'
               example:
@@ -3782,7 +3782,7 @@ paths:
         '200':
           description: successful operation
           content:
-            application/json:
+            application/json; charset=utf-8:
               schema:
                 type: array
                 items:
@@ -3806,7 +3806,7 @@ paths:
       requestBody:
         required: true
         content:
-          application/json:
+          application/json; charset=utf-8:
             schema:
               $ref: '#/components/schemas/Share'
       responses:
@@ -3822,7 +3822,7 @@ paths:
                 type: string
               description: URL to retrieve the details for the new created share
           content:
-            application/json:
+            application/json; charset=utf-8:
               schema:
                 $ref: '#/components/schemas/ApiResponse'
         '400':
@@ -3853,7 +3853,7 @@ paths:
         '200':
           description: successful operation
           content:
-            application/json:
+            application/json; charset=utf-8:
               schema:
                 $ref: '#/components/schemas/Share'
         '400':
@@ -3877,14 +3877,14 @@ paths:
       requestBody:
         required: true
         content:
-          application/json:
+          application/json; charset=utf-8:
             schema:
               $ref: '#/components/schemas/Share'
       responses:
         '200':
           description: successful operation
           content:
-            application/json:
+            application/json; charset=utf-8:
               schema:
                 $ref: '#/components/schemas/ApiResponse'
               example:
@@ -3911,7 +3911,7 @@ paths:
         '200':
           description: successful operation
           content:
-            application/json:
+            application/json; charset=utf-8:
               schema:
                 $ref: '#/components/schemas/ApiResponse'
               example:
@@ -3945,7 +3945,7 @@ paths:
         '200':
           description: successful operation
           content:
-            application/json:
+            application/json; charset=utf-8:
               schema:
                 type: array
                 items:
@@ -3983,7 +3983,7 @@ paths:
         '201':
           description: successful operation
           content:
-            application/json:
+            application/json; charset=utf-8:
               schema:
                 type: array
                 items:
@@ -4021,7 +4021,7 @@ paths:
         '200':
           description: successful operation
           content:
-            application/json:
+            application/json; charset=utf-8:
               schema:
                 type: array
                 items:
@@ -4053,7 +4053,7 @@ paths:
         '200':
           description: successful operation
           content:
-            application/json:
+            application/json; charset=utf-8:
               schema:
                 type: array
                 items:
@@ -4149,7 +4149,7 @@ paths:
         '201':
           description: successful operation
           content:
-            application/json:
+            application/json; charset=utf-8:
               schema:
                 type: array
                 items:
@@ -4189,7 +4189,7 @@ paths:
         '200':
           description: successful operation
           content:
-            application/json:
+            application/json; charset=utf-8:
               schema:
                 type: array
                 items:
@@ -4221,7 +4221,7 @@ paths:
         '200':
           description: successful operation
           content:
-            application/json:
+            application/json; charset=utf-8:
               schema:
                 type: array
                 items:
@@ -4288,7 +4288,7 @@ paths:
         '201':
           description: successful operation
           content:
-            application/json:
+            application/json; charset=utf-8:
               schema:
                 type: array
                 items:
@@ -4321,7 +4321,7 @@ paths:
           required: true
       requestBody:
         content:
-          application/json:
+          application/json; charset=utf-8:
             schema:
               type: object
               properties:
@@ -4333,7 +4333,7 @@ paths:
         '200':
           description: successful operation
           content:
-            application/json:
+            application/json; charset=utf-8:
               schema:
                 type: array
                 items:
@@ -4360,7 +4360,7 @@ paths:
       requestBody:
         required: true
         content:
-          application/json:
+          application/json; charset=utf-8:
             schema:
               type: array
               items:
@@ -4389,49 +4389,49 @@ components:
     BadRequest:
       description: Bad Request
       content:
-        application/json:
+        application/json; charset=utf-8:
           schema:
             $ref: '#/components/schemas/ApiResponse'
     Unauthorized:
       description: Unauthorized
       content:
-        application/json:
+        application/json; charset=utf-8:
           schema:
             $ref: '#/components/schemas/ApiResponse'
     Forbidden:
       description: Forbidden
       content:
-        application/json:
+        application/json; charset=utf-8:
           schema:
             $ref: '#/components/schemas/ApiResponse'
     NotFound:
       description: Not Found
       content:
-        application/json:
+        application/json; charset=utf-8:
           schema:
             $ref: '#/components/schemas/ApiResponse'
     Conflict:
       description: Conflict
       content:
-        application/json:
+        application/json; charset=utf-8:
           schema:
             $ref: '#/components/schemas/ApiResponse'
     RequestEntityTooLarge:
       description: Request Entity Too Large, max allowed size exceeded
       content:
-        application/json:
+        application/json; charset=utf-8:
           schema:
             $ref: '#/components/schemas/ApiResponse'
     InternalServerError:
       description: Internal Server Error
       content:
-        application/json:
+        application/json; charset=utf-8:
           schema:
             $ref: '#/components/schemas/ApiResponse'
     DefaultResponse:
       description: Unexpected Error
       content:
-        application/json:
+        application/json; charset=utf-8:
           schema:
             $ref: '#/components/schemas/ApiResponse'
   schemas:

--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -6728,4 +6728,3 @@ components:
       in: header
       name: X-SFTPGO-API-KEY
       description: 'API key to use for authentication. API key authentication is intrinsically less secure than using a short lived JWT token. You should prefer API key authentication only for machine-to-machine communications in trusted environments. If no admin/user is associated to the provided key you need to add ".username" at the end of the key. For example if your API key is "6ajKLwswLccVBGpZGv596G.ySAXc8vtp9hMiwAuaLtzof" and you want to impersonate the admin with username "myadmin" you have to use "6ajKLwswLccVBGpZGv596G.ySAXc8vtp9hMiwAuaLtzof.myadmin" as API key. When using API key authentication you cannot manage API keys, update the impersonated admin, change password or public keys for the impersonated user.'
-

--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -6728,3 +6728,4 @@ components:
       in: header
       name: X-SFTPGO-API-KEY
       description: 'API key to use for authentication. API key authentication is intrinsically less secure than using a short lived JWT token. You should prefer API key authentication only for machine-to-machine communications in trusted environments. If no admin/user is associated to the provided key you need to add ".username" at the end of the key. For example if your API key is "6ajKLwswLccVBGpZGv596G.ySAXc8vtp9hMiwAuaLtzof" and you want to impersonate the admin with username "myadmin" you have to use "6ajKLwswLccVBGpZGv596G.ySAXc8vtp9hMiwAuaLtzof.myadmin" as API key. When using API key authentication you cannot manage API keys, update the impersonated admin, change password or public keys for the impersonated user.'
+


### PR DESCRIPTION
This change is linked to https://github.com/drakkan/sftpgo/issues/1101 and should partially alleviate the need to change the content type in the files generated by openapi-generator-cli

Signed-off-by: Jon Bendtsen <github@jonb.dk>