### PR TITLE
Send output from external_auth_hook to logs

### DIFF
--- a/docs/external-auth.md
+++ b/docs/external-auth.md
@@ -21,6 +21,8 @@ The program must write, on its standard output:
 - an empty string, or no response at all, if authentication succeeds and the existing SFTPGo user does not need to be updated. This means that the credentials already stored in SFTPGo must match those used for the current authentication.
 - a user with an empty username if the authentication fails
 
+Any output of the program on its standard error will be recorded in the sftpgo logs with sender `external_auth_hook`.
+
 If the hook is an HTTP URL then it will be invoked as HTTP POST. The request body will contain a JSON serialized struct with the following fields:
 
 - `username`


### PR DESCRIPTION
This allows an `external_auth_hook` program to send messages to the sftpgo logs.

Any output on stderr is logged with a special sender ("external_auth_hook") at severity warning.

My use-case is a deployment using docker, where syslog is not available. The change should be backwards compatible and the [ldapauth example](https://github.com/drakkan/sftpgo/tree/main/examples/ldapauth) automatically falls back to stderr when syslog is unavailble, so this fits nicely.

Thanks a lot for this tremendous piece of software! :heart: 