### PR TITLE
Fix potential ldap injection

### DIFF
--- a/examples/ldapauth/main.go
+++ b/examples/ldapauth/main.go
@@ -97,7 +97,7 @@ func main() {
 
 	// search the user trying to login and fetch some attributes, this search string is tested against 389ds using the default configuration
 	log.Printf("username=%s\n", username)
-	searchFilter := fmt.Sprintf("(uid=%s)", username)
+	searchFilter := fmt.Sprintf("(uid=%s)", ldap.EscapeFilter(username))
 	searchRequest := ldap.NewSearchRequest(
 		"ou=people," + rootDN,
 		ldap.ScopeWholeSubtree, ldap.NeverDerefAliases, 0, 0, false,

--- a/examples/ldapauthserver/httpd/ldapauth.go
+++ b/examples/ldapauthserver/httpd/ldapauth.go
@@ -78,7 +78,7 @@ func checkSFTPGoUserAuth(w http.ResponseWriter, r *http.Request) {
 	searchRequest := ldap.NewSearchRequest(
 		ldapConfig.BaseDN,
 		ldap.ScopeWholeSubtree, ldap.NeverDerefAliases, 0, 0, false,
-		strings.Replace(ldapConfig.SearchFilter, "%s", authReq.Username, 1),
+		strings.Replace(ldapConfig.SearchFilter, "%s", ldap.EscapeFilter(authReq.Username), 1),
 		ldapConfig.SearchBaseAttrs,
 		nil,
 	)


### PR DESCRIPTION
This fixes an ldap injection in the ldapauth examples.

I can't immediately come up an example how (if at all) this could be exploited.

However, that sentence is a prime candidate for a list of "famous last words", so it should probably be fixed nonetheless.