### PR TITLE
Setuid as user for OsFs operations

### DIFF
--- a/internal/common/actions_test.go
+++ b/internal/common/actions_test.go
@@ -262,7 +262,7 @@ func TestPreDeleteAction(t *testing.T) {
 	}
 	user.Permissions = make(map[string][]string)
 	user.Permissions["/"] = []string{dataprovider.PermAny}
-	fs := vfs.NewOsFs("id", homeDir, "")
+	fs := vfs.NewOsFs("id", homeDir, "", 0, 0)
 	c := NewBaseConnection("id", ProtocolSFTP, "", "", user)
 
 	testfile := filepath.Join(user.HomeDir, "testfile")

--- a/internal/common/common_test.go
+++ b/internal/common/common_test.go
@@ -830,7 +830,7 @@ func TestConnectionStatus(t *testing.T) {
 			Username: username,
 		},
 	}
-	fs := vfs.NewOsFs("", os.TempDir(), "")
+	fs := vfs.NewOsFs("", os.TempDir(), "", 0, 0)
 	c1 := NewBaseConnection("id1", ProtocolSFTP, "", "", user)
 	fakeConn1 := &fakeConnection{
 		BaseConnection: c1,

--- a/internal/common/connection.go
+++ b/internal/common/connection.go
@@ -365,7 +365,6 @@ func (c *BaseConnection) CreateDir(virtualPath string, checkFilePatterns bool) e
 		c.Log(logger.LevelError, "error creating dir: %q error: %+v", fsPath, err)
 		return c.GetFsError(fs, err)
 	}
-	vfs.SetPathPermissions(fs, fsPath, c.User.GetUID(), c.User.GetGID())
 	elapsed := time.Since(startTime).Nanoseconds() / 1000000
 
 	logger.CommandLog(mkdirLogSender, fsPath, "", c.User.Username, "", c.ID, c.protocol, -1, -1, "", "", "", -1,
@@ -764,7 +763,6 @@ func (c *BaseConnection) renameInternal(virtualSourcePath, virtualTargetPath str
 		c.Log(logger.LevelError, "failed to rename %q -> %q: %+v", fsSourcePath, fsTargetPath, err)
 		return c.GetFsError(fsSrc, err)
 	}
-	vfs.SetPathPermissions(fsDst, fsTargetPath, c.User.GetUID(), c.User.GetGID())
 	elapsed := time.Since(startTime).Nanoseconds() / 1000000
 	c.updateQuotaAfterRename(fsDst, virtualSourcePath, virtualTargetPath, fsTargetPath, initialSize, files, size) //nolint:errcheck
 	logger.CommandLog(renameLogSender, fsSourcePath, fsTargetPath, c.User.Username, "", c.ID, c.protocol, -1, -1,

--- a/internal/common/connection_test.go
+++ b/internal/common/connection_test.go
@@ -86,7 +86,7 @@ func (fs *MockOsFs) Walk(root string, walkFn filepath.WalkFunc) error {
 
 func newMockOsFs(hasVirtualFolders bool, connectionID, rootDir, name string, err error) vfs.Fs {
 	return &MockOsFs{
-		Fs:                vfs.NewOsFs(connectionID, rootDir, ""),
+		Fs:                vfs.NewOsFs(connectionID, rootDir, "", 0, 0),
 		name:              name,
 		hasVirtualFolders: hasVirtualFolders,
 		err:               err,
@@ -114,7 +114,7 @@ func TestRemoveErrors(t *testing.T) {
 	}
 	user.Permissions = make(map[string][]string)
 	user.Permissions["/"] = []string{dataprovider.PermAny}
-	fs := vfs.NewOsFs("", os.TempDir(), "")
+	fs := vfs.NewOsFs("", os.TempDir(), "", 0, 0)
 	conn := NewBaseConnection("", ProtocolFTP, "", "", user)
 	err := conn.IsRemoveDirAllowed(fs, mappedPath, "/virtualpath1")
 	if assert.Error(t, err) {
@@ -159,7 +159,7 @@ func TestSetStatMode(t *testing.T) {
 }
 
 func TestRecursiveRenameWalkError(t *testing.T) {
-	fs := vfs.NewOsFs("", filepath.Clean(os.TempDir()), "")
+	fs := vfs.NewOsFs("", filepath.Clean(os.TempDir()), "", 0, 0)
 	conn := NewBaseConnection("", ProtocolWebDAV, "", "", dataprovider.User{
 		BaseUser: sdk.BaseUser{
 			Permissions: map[string][]string{
@@ -193,7 +193,7 @@ func TestRecursiveRenameWalkError(t *testing.T) {
 }
 
 func TestCrossRenameFsErrors(t *testing.T) {
-	fs := vfs.NewOsFs("", os.TempDir(), "")
+	fs := vfs.NewOsFs("", os.TempDir(), "", 0, 0)
 	conn := NewBaseConnection("", ProtocolWebDAV, "", "", dataprovider.User{})
 	res := conn.hasSpaceForCrossRename(fs, vfs.QuotaCheckResult{}, 1, "missingsource")
 	assert.False(t, res)
@@ -224,7 +224,7 @@ func TestRenameVirtualFolders(t *testing.T) {
 		},
 		VirtualPath: vdir,
 	})
-	fs := vfs.NewOsFs("", os.TempDir(), "")
+	fs := vfs.NewOsFs("", os.TempDir(), "", 0, 0)
 	conn := NewBaseConnection("", ProtocolFTP, "", "", u)
 	res := conn.isRenamePermitted(fs, fs, "source", "target", vdir, "vdirtarget", nil)
 	assert.False(t, res)
@@ -376,7 +376,7 @@ func TestUpdateQuotaAfterRename(t *testing.T) {
 }
 
 func TestErrorsMapping(t *testing.T) {
-	fs := vfs.NewOsFs("", os.TempDir(), "")
+	fs := vfs.NewOsFs("", os.TempDir(), "", 0, 0)
 	conn := NewBaseConnection("", ProtocolSFTP, "", "", dataprovider.User{BaseUser: sdk.BaseUser{HomeDir: os.TempDir()}})
 	osErrorsProtocols := []string{ProtocolWebDAV, ProtocolFTP, ProtocolHTTP, ProtocolHTTPShare,
 		ProtocolDataRetention, ProtocolOIDC, protocolEventAction}

--- a/internal/common/eventmanager.go
+++ b/internal/common/eventmanager.go
@@ -795,7 +795,6 @@ func getFileWriter(conn *BaseConnection, virtualPath string, expectedSize int64)
 	if err != nil {
 		return nil, numFiles, truncatedSize, nil, conn.GetFsError(fs, err)
 	}
-	vfs.SetPathPermissions(fs, fsPath, conn.User.GetUID(), conn.User.GetGID())
 
 	if isFileOverwrite {
 		if vfs.HasTruncateSupport(fs) || vfs.IsCryptOsFs(fs) {
@@ -1927,7 +1926,7 @@ func executeFoldersQuotaResetRuleAction(conditions dataprovider.ConditionOptions
 			BaseVirtualFolder: folder,
 			VirtualPath:       "/",
 		}
-		numFiles, size, err := f.ScanQuota()
+		numFiles, size, err := f.ScanQuota(0, 0)
 		QuotaScans.RemoveVFolderQuotaScan(folder.Name)
 		if err != nil {
 			eventManagerLog(logger.LevelError, "error scanning quota for folder %q: %v", folder.Name, err)

--- a/internal/common/transfer_test.go
+++ b/internal/common/transfer_test.go
@@ -35,7 +35,7 @@ func TestTransferUpdateQuota(t *testing.T) {
 	transfer := BaseTransfer{
 		Connection:   conn,
 		transferType: TransferUpload,
-		Fs:           vfs.NewOsFs("", os.TempDir(), ""),
+		Fs:           vfs.NewOsFs("", os.TempDir(), "", 0, 0),
 	}
 	transfer.BytesReceived.Store(123)
 	errFake := errors.New("fake error")
@@ -74,7 +74,7 @@ func TestTransferThrottling(t *testing.T) {
 			DownloadBandwidth: 40,
 		},
 	}
-	fs := vfs.NewOsFs("", os.TempDir(), "")
+	fs := vfs.NewOsFs("", os.TempDir(), "", 0, 0)
 	testFileSize := int64(131072)
 	wantedUploadElapsed := 1000 * (testFileSize / 1024) / u.UploadBandwidth
 	wantedDownloadElapsed := 1000 * (testFileSize / 1024) / u.DownloadBandwidth
@@ -106,7 +106,7 @@ func TestTransferThrottling(t *testing.T) {
 
 func TestRealPath(t *testing.T) {
 	testFile := filepath.Join(os.TempDir(), "afile.txt")
-	fs := vfs.NewOsFs("123", os.TempDir(), "")
+	fs := vfs.NewOsFs("123", os.TempDir(), "", 0, 0)
 	u := dataprovider.User{
 		BaseUser: sdk.BaseUser{
 			Username: "user",
@@ -140,7 +140,7 @@ func TestRealPath(t *testing.T) {
 
 func TestTruncate(t *testing.T) {
 	testFile := filepath.Join(os.TempDir(), "transfer_test_file")
-	fs := vfs.NewOsFs("123", os.TempDir(), "")
+	fs := vfs.NewOsFs("123", os.TempDir(), "", 0, 0)
 	u := dataprovider.User{
 		BaseUser: sdk.BaseUser{
 			Username: "user",
@@ -209,7 +209,7 @@ func TestTransferErrors(t *testing.T) {
 		isCancelled = true
 	}
 	testFile := filepath.Join(os.TempDir(), "transfer_test_file")
-	fs := vfs.NewOsFs("id", os.TempDir(), "")
+	fs := vfs.NewOsFs("id", os.TempDir(), "", 0, 0)
 	u := dataprovider.User{
 		BaseUser: sdk.BaseUser{
 			Username: "test",
@@ -316,7 +316,7 @@ func TestFTPMode(t *testing.T) {
 	transfer := BaseTransfer{
 		Connection:   conn,
 		transferType: TransferUpload,
-		Fs:           vfs.NewOsFs("", os.TempDir(), ""),
+		Fs:           vfs.NewOsFs("", os.TempDir(), "", 0, 0),
 	}
 	transfer.BytesReceived.Store(123)
 	assert.Empty(t, transfer.ftpMode)
@@ -394,7 +394,7 @@ func TestTransferQuota(t *testing.T) {
 
 	conn := NewBaseConnection("", ProtocolSFTP, "", "", user)
 	transfer := NewBaseTransfer(nil, conn, nil, "file.txt", "file.txt", "/transfer_test_file", TransferUpload,
-		0, 0, 0, 0, true, vfs.NewOsFs("", os.TempDir(), ""), dataprovider.TransferQuota{})
+		0, 0, 0, 0, true, vfs.NewOsFs("", os.TempDir(), "", 0, 0), dataprovider.TransferQuota{})
 	err := transfer.CheckRead()
 	assert.NoError(t, err)
 	err = transfer.CheckWrite()
@@ -448,7 +448,7 @@ func TestUploadOutsideHomeRenameError(t *testing.T) {
 	transfer := BaseTransfer{
 		Connection:   conn,
 		transferType: TransferUpload,
-		Fs:           vfs.NewOsFs("", filepath.Join(os.TempDir(), "home"), ""),
+		Fs:           vfs.NewOsFs("", filepath.Join(os.TempDir(), "home"), "", 0, 0),
 	}
 	transfer.BytesReceived.Store(123)
 

--- a/internal/ftpd/handler.go
+++ b/internal/ftpd/handler.go
@@ -414,8 +414,6 @@ func (c *Connection) handleFTPUploadToNewFile(fs vfs.Fs, flags int, resolvedPath
 		return nil, c.GetFsError(fs, err)
 	}
 
-	vfs.SetPathPermissions(fs, filePath, c.User.GetUID(), c.User.GetGID())
-
 	// we can get an error only for resume
 	maxWriteSize, _ := c.GetMaxWriteSize(diskQuota, false, 0, fs.IsUploadResumeSupported())
 
@@ -495,8 +493,6 @@ func (c *Connection) handleFTPUploadToExistingFile(fs vfs.Fs, flags int, resolve
 			truncatedSize = fileSize
 		}
 	}
-
-	vfs.SetPathPermissions(fs, filePath, c.User.GetUID(), c.User.GetGID())
 
 	baseTransfer := common.NewBaseTransfer(file, c.BaseConnection, cancelFn, resolvedPath, filePath, requestPath,
 		common.TransferUpload, minWriteOffset, initialSize, maxWriteSize, truncatedSize, false, fs, transferQuota)

--- a/internal/ftpd/internal_test.go
+++ b/internal/ftpd/internal_test.go
@@ -398,7 +398,7 @@ func (fs MockOsFs) Rename(source, target string) (int, int64, error) {
 
 func newMockOsFs(err, statErr error, atomicUpload bool, connectionID, rootDir string) vfs.Fs {
 	return &MockOsFs{
-		Fs:                      vfs.NewOsFs(connectionID, rootDir, ""),
+		Fs:                      vfs.NewOsFs(connectionID, rootDir, "", 0, 0),
 		err:                     err,
 		statErr:                 statErr,
 		isAtomicUploadSupported: atomicUpload,
@@ -723,7 +723,7 @@ func TestUploadFileStatError(t *testing.T) {
 	user.Permissions["/"] = []string{dataprovider.PermAny}
 	mockCC := mockFTPClientContext{}
 	connID := fmt.Sprintf("%v", mockCC.ID())
-	fs := vfs.NewOsFs(connID, user.HomeDir, "")
+	fs := vfs.NewOsFs(connID, user.HomeDir, "", 0, 0)
 	connection := &Connection{
 		BaseConnection: common.NewBaseConnection(connID, common.ProtocolFTP, "", "", user),
 		clientContext:  mockCC,
@@ -813,7 +813,7 @@ func TestUploadOverwriteErrors(t *testing.T) {
 	_, err = connection.handleFTPUploadToExistingFile(fs, os.O_TRUNC, filepath.Join(os.TempDir(), "sub", "file"),
 		filepath.Join(os.TempDir(), "sub", "file1"), 0, "/sub/file1")
 	assert.Error(t, err)
-	fs = vfs.NewOsFs(connID, user.GetHomeDir(), "")
+	fs = vfs.NewOsFs(connID, user.GetHomeDir(), "", 0, 0)
 	_, err = connection.handleFTPUploadToExistingFile(fs, 0, "missing1", "missing2", 0, "missing")
 	assert.Error(t, err)
 }

--- a/internal/httpd/api_quota.go
+++ b/internal/httpd/api_quota.go
@@ -260,7 +260,7 @@ func doFolderQuotaScan(folder vfs.BaseVirtualFolder) error {
 		BaseVirtualFolder: folder,
 		VirtualPath:       "/",
 	}
-	numFiles, size, err := f.ScanQuota()
+	numFiles, size, err := f.ScanQuota(0, 0)
 	if err != nil {
 		logger.Warn(logSender, "", "error scanning folder %q: %v", folder.Name, err)
 		return err

--- a/internal/httpd/handler.go
+++ b/internal/httpd/handler.go
@@ -229,8 +229,6 @@ func (c *Connection) handleUploadFile(fs vfs.Fs, resolvedPath, filePath, request
 		}
 	}
 
-	vfs.SetPathPermissions(fs, filePath, c.User.GetUID(), c.User.GetGID())
-
 	baseTransfer := common.NewBaseTransfer(file, c.BaseConnection, cancelFn, resolvedPath, filePath, requestPath,
 		common.TransferUpload, 0, initialSize, maxWriteSize, truncatedSize, isNewFile, fs, transferQuota)
 	return newHTTPDFile(baseTransfer, w, nil), nil

--- a/internal/httpd/httpd_test.go
+++ b/internal/httpd/httpd_test.go
@@ -12012,7 +12012,7 @@ func TestWebClientMaxConnections(t *testing.T) {
 	checkResponseCode(t, http.StatusOK, rr)
 
 	// now add a fake connection
-	fs := vfs.NewOsFs("id", os.TempDir(), "")
+	fs := vfs.NewOsFs("id", os.TempDir(), "", 0, 0)
 	connection := &httpd.Connection{
 		BaseConnection: common.NewBaseConnection(fs.ConnectionID(), common.ProtocolHTTP, "", "", user),
 	}
@@ -12203,7 +12203,7 @@ func TestMaxSessions(t *testing.T) {
 	apiToken, err := getJWTAPIUserTokenFromTestServer(defaultUsername, defaultPassword)
 	assert.NoError(t, err)
 	// now add a fake connection
-	fs := vfs.NewOsFs("id", os.TempDir(), "")
+	fs := vfs.NewOsFs("id", os.TempDir(), "", 0, 0)
 	connection := &httpd.Connection{
 		BaseConnection: common.NewBaseConnection(fs.ConnectionID(), common.ProtocolHTTP, "", "", user),
 	}
@@ -13312,7 +13312,7 @@ func TestShareMaxSessions(t *testing.T) {
 	rr = executeRequest(req)
 	checkResponseCode(t, http.StatusOK, rr)
 	// add a fake connection
-	fs := vfs.NewOsFs("id", os.TempDir(), "")
+	fs := vfs.NewOsFs("id", os.TempDir(), "", 0, 0)
 	connection := &httpd.Connection{
 		BaseConnection: common.NewBaseConnection(fs.ConnectionID(), common.ProtocolHTTP, "", "", user),
 	}

--- a/internal/sftpd/handler.go
+++ b/internal/sftpd/handler.go
@@ -413,8 +413,6 @@ func (c *Connection) handleSFTPUploadToNewFile(fs vfs.Fs, pflags sftp.FileOpenFl
 		return nil, c.GetFsError(fs, err)
 	}
 
-	vfs.SetPathPermissions(fs, filePath, c.User.GetUID(), c.User.GetGID())
-
 	// we can get an error only for resume
 	maxWriteSize, _ := c.GetMaxWriteSize(diskQuota, false, 0, fs.IsUploadResumeSupported())
 
@@ -496,8 +494,6 @@ func (c *Connection) handleSFTPUploadToExistingFile(fs vfs.Fs, pflags sftp.FileO
 			truncatedSize = fileSize
 		}
 	}
-
-	vfs.SetPathPermissions(fs, filePath, c.User.GetUID(), c.User.GetGID())
 
 	baseTransfer := common.NewBaseTransfer(file, c.BaseConnection, cancelFn, resolvedPath, filePath, requestPath,
 		common.TransferUpload, minWriteOffset, initialSize, maxWriteSize, truncatedSize, false, fs, transferQuota)

--- a/internal/sftpd/internal_test.go
+++ b/internal/sftpd/internal_test.go
@@ -149,7 +149,7 @@ func (fs MockOsFs) Rename(source, target string) (int, int64, error) {
 
 func newMockOsFs(err, statErr error, atomicUpload bool, connectionID, rootDir string) vfs.Fs {
 	return &MockOsFs{
-		Fs:                      vfs.NewOsFs(connectionID, rootDir, ""),
+		Fs:                      vfs.NewOsFs(connectionID, rootDir, "", 0, 0),
 		err:                     err,
 		statErr:                 statErr,
 		isAtomicUploadSupported: atomicUpload,
@@ -183,7 +183,7 @@ func TestUploadResumeInvalidOffset(t *testing.T) {
 			Username: "testuser",
 		},
 	}
-	fs := vfs.NewOsFs("", os.TempDir(), "")
+	fs := vfs.NewOsFs("", os.TempDir(), "", 0, 0)
 	conn := common.NewBaseConnection("", common.ProtocolSFTP, "", "", user)
 	baseTransfer := common.NewBaseTransfer(file, conn, nil, file.Name(), file.Name(), testfile,
 		common.TransferUpload, 10, 0, 0, 0, false, fs, dataprovider.TransferQuota{})
@@ -214,7 +214,7 @@ func TestReadWriteErrors(t *testing.T) {
 			Username: "testuser",
 		},
 	}
-	fs := vfs.NewOsFs("", os.TempDir(), "")
+	fs := vfs.NewOsFs("", os.TempDir(), "", 0, 0)
 	conn := common.NewBaseConnection("", common.ProtocolSFTP, "", "", user)
 	baseTransfer := common.NewBaseTransfer(file, conn, nil, file.Name(), file.Name(), testfile, common.TransferDownload,
 		0, 0, 0, 0, false, fs, dataprovider.TransferQuota{})
@@ -288,7 +288,7 @@ func TestTransferCancelFn(t *testing.T) {
 			Username: "testuser",
 		},
 	}
-	fs := vfs.NewOsFs("", os.TempDir(), "")
+	fs := vfs.NewOsFs("", os.TempDir(), "", 0, 0)
 	conn := common.NewBaseConnection("", common.ProtocolSFTP, "", "", user)
 	baseTransfer := common.NewBaseTransfer(file, conn, cancelFn, file.Name(), file.Name(), testfile, common.TransferDownload,
 		0, 0, 0, 0, false, fs, dataprovider.TransferQuota{})
@@ -311,7 +311,7 @@ func TestTransferCancelFn(t *testing.T) {
 
 func TestUploadFiles(t *testing.T) {
 	common.Config.UploadMode = common.UploadModeAtomic
-	fs := vfs.NewOsFs("123", os.TempDir(), "")
+	fs := vfs.NewOsFs("123", os.TempDir(), "", 0, 0)
 	u := dataprovider.User{}
 	c := Connection{
 		BaseConnection: common.NewBaseConnection("", common.ProtocolSFTP, "", "", u),
@@ -1213,7 +1213,7 @@ func TestSCPParseUploadMessage(t *testing.T) {
 		StdErrBuffer: bytes.NewBuffer(stdErrBuf),
 		ReadError:    nil,
 	}
-	fs := vfs.NewOsFs("", os.TempDir(), "")
+	fs := vfs.NewOsFs("", os.TempDir(), "", 0, 0)
 	connection := &Connection{
 		BaseConnection: common.NewBaseConnection("", common.ProtocolSFTP, "", "", dataprovider.User{
 			BaseUser: sdk.BaseUser{
@@ -1470,7 +1470,7 @@ func TestSCPRecursiveDownloadErrors(t *testing.T) {
 		err := client.Close()
 		assert.NoError(t, err)
 	}()
-	fs := vfs.NewOsFs("123", os.TempDir(), "")
+	fs := vfs.NewOsFs("123", os.TempDir(), "", 0, 0)
 	connection := &Connection{
 		BaseConnection: common.NewBaseConnection("", common.ProtocolSCP, "", "", dataprovider.User{
 			BaseUser: sdk.BaseUser{
@@ -1593,7 +1593,7 @@ func TestSCPDownloadFileData(t *testing.T) {
 		ReadError:    nil,
 		WriteError:   writeErr,
 	}
-	fs := vfs.NewOsFs("", os.TempDir(), "")
+	fs := vfs.NewOsFs("", os.TempDir(), "", 0, 0)
 	connection := &Connection{
 		BaseConnection: common.NewBaseConnection("", common.ProtocolSCP, "", "", dataprovider.User{BaseUser: sdk.BaseUser{HomeDir: os.TempDir()}}),
 		channel:        &mockSSHChannelReadErr,
@@ -1645,7 +1645,7 @@ func TestSCPUploadFiledata(t *testing.T) {
 			Username: "testuser",
 		},
 	}
-	fs := vfs.NewOsFs("", os.TempDir(), "")
+	fs := vfs.NewOsFs("", os.TempDir(), "", 0, 0)
 	connection := &Connection{
 		BaseConnection: common.NewBaseConnection("", common.ProtocolSCP, "", "", user),
 		channel:        &mockSSHChannel,
@@ -1736,7 +1736,7 @@ func TestUploadError(t *testing.T) {
 			Username: "testuser",
 		},
 	}
-	fs := vfs.NewOsFs("", os.TempDir(), "")
+	fs := vfs.NewOsFs("", os.TempDir(), "", 0, 0)
 	connection := &Connection{
 		BaseConnection: common.NewBaseConnection("", common.ProtocolSCP, "", "", user),
 	}

--- a/internal/sftpd/scp.go
+++ b/internal/sftpd/scp.go
@@ -276,8 +276,6 @@ func (c *scpCommand) handleUploadFile(fs vfs.Fs, resolvedPath, filePath string, 
 		}
 	}
 
-	vfs.SetPathPermissions(fs, filePath, c.connection.User.GetUID(), c.connection.User.GetGID())
-
 	baseTransfer := common.NewBaseTransfer(file, c.connection.BaseConnection, cancelFn, resolvedPath, filePath, requestPath,
 		common.TransferUpload, 0, initialSize, maxWriteSize, truncatedSize, isNewFile, fs, transferQuota)
 	t := newTransfer(baseTransfer, w, nil, nil)
@@ -689,7 +687,6 @@ func (c *scpCommand) createDir(fs vfs.Fs, dirPath string) error {
 		c.sendErrorMessage(fs, err)
 		return err
 	}
-	vfs.SetPathPermissions(fs, dirPath, c.connection.User.GetUID(), c.connection.User.GetGID())
 	return err
 }
 

--- a/internal/sftpd/sftpd_test.go
+++ b/internal/sftpd/sftpd_test.go
@@ -8047,7 +8047,7 @@ func TestRootDirCommands(t *testing.T) {
 func TestRelativePaths(t *testing.T) {
 	user := getTestUser(true)
 	var path, rel string
-	filesystems := []vfs.Fs{vfs.NewOsFs("", user.GetHomeDir(), "")}
+	filesystems := []vfs.Fs{vfs.NewOsFs("", user.GetHomeDir(), "", 0, 0)}
 	keyPrefix := strings.TrimPrefix(user.GetHomeDir(), "/") + "/"
 	s3config := vfs.S3FsConfig{
 		BaseS3FsConfig: sdk.BaseS3FsConfig{
@@ -8112,7 +8112,7 @@ func TestResolvePaths(t *testing.T) {
 	user := getTestUser(true)
 	var path, resolved string
 	var err error
-	filesystems := []vfs.Fs{vfs.NewOsFs("", user.GetHomeDir(), "")}
+	filesystems := []vfs.Fs{vfs.NewOsFs("", user.GetHomeDir(), "", 0, 0)}
 	keyPrefix := strings.TrimPrefix(user.GetHomeDir(), "/") + "/"
 	s3config := vfs.S3FsConfig{
 		BaseS3FsConfig: sdk.BaseS3FsConfig{
@@ -8175,8 +8175,8 @@ func TestVirtualRelativePaths(t *testing.T) {
 	})
 	err := os.MkdirAll(mappedPath, os.ModePerm)
 	assert.NoError(t, err)
-	fsRoot := vfs.NewOsFs("", user.GetHomeDir(), "")
-	fsVdir := vfs.NewOsFs("", mappedPath, vdirPath)
+	fsRoot := vfs.NewOsFs("", user.GetHomeDir(), "", 0, 0)
+	fsVdir := vfs.NewOsFs("", mappedPath, vdirPath, 0, 0)
 	rel := fsVdir.GetRelativePath(mappedPath)
 	assert.Equal(t, vdirPath, rel)
 	rel = fsRoot.GetRelativePath(filepath.Join(mappedPath, ".."))

--- a/internal/vfs/azblobfs.go
+++ b/internal/vfs/azblobfs.go
@@ -507,7 +507,7 @@ func (*AzureBlobFs) isBadRequestError(err error) bool {
 // CheckRootPath creates the specified local root directory if it does not exists
 func (fs *AzureBlobFs) CheckRootPath(username string, uid int, gid int) bool {
 	// we need a local directory for temporary files
-	osFs := NewOsFs(fs.ConnectionID(), fs.localTempDir, "")
+	osFs := NewOsFs(fs.ConnectionID(), fs.localTempDir, "", uid, gid)
 	return osFs.CheckRootPath(username, uid, gid)
 }
 

--- a/internal/vfs/folder.go
+++ b/internal/vfs/folder.go
@@ -192,7 +192,7 @@ type VirtualFolder struct {
 }
 
 // GetFilesystem returns the filesystem for this folder
-func (v *VirtualFolder) GetFilesystem(connectionID string, forbiddenSelfUsers []string) (Fs, error) {
+func (v *VirtualFolder) GetFilesystem(connectionID string, uid, gid int, forbiddenSelfUsers []string) (Fs, error) {
 	switch v.FsConfig.Provider {
 	case sdk.S3FilesystemProvider:
 		return NewS3Fs(connectionID, v.MappedPath, v.VirtualPath, v.FsConfig.S3Config)
@@ -207,14 +207,14 @@ func (v *VirtualFolder) GetFilesystem(connectionID string, forbiddenSelfUsers []
 	case sdk.HTTPFilesystemProvider:
 		return NewHTTPFs(connectionID, v.MappedPath, v.VirtualPath, v.FsConfig.HTTPConfig)
 	default:
-		return NewOsFs(connectionID, v.MappedPath, v.VirtualPath), nil
+		return NewOsFs(connectionID, v.MappedPath, v.VirtualPath, uid, gid), nil
 	}
 }
 
 // CheckMetadataConsistency checks the consistency between the metadata stored
 // in the configured metadata plugin and the filesystem
-func (v *VirtualFolder) CheckMetadataConsistency() error {
-	fs, err := v.GetFilesystem(xid.New().String(), nil)
+func (v *VirtualFolder) CheckMetadataConsistency(uid, gid int) error {
+	fs, err := v.GetFilesystem(xid.New().String(), uid, gid, nil)
 	if err != nil {
 		return err
 	}
@@ -224,11 +224,11 @@ func (v *VirtualFolder) CheckMetadataConsistency() error {
 }
 
 // ScanQuota scans the folder and returns the number of files and their size
-func (v *VirtualFolder) ScanQuota() (int, int64, error) {
+func (v *VirtualFolder) ScanQuota(uid, gid int) (int, int64, error) {
 	if v.hasPathPlaceholder() {
 		return 0, 0, errors.New("cannot scan quota: this folder has a path placeholder")
 	}
-	fs, err := v.GetFilesystem(xid.New().String(), nil)
+	fs, err := v.GetFilesystem(xid.New().String(), uid, gid, nil)
 	if err != nil {
 		return 0, 0, err
 	}

--- a/internal/vfs/gcsfs.go
+++ b/internal/vfs/gcsfs.go
@@ -462,7 +462,7 @@ func (*GCSFs) IsNotSupported(err error) bool {
 // CheckRootPath creates the specified local root directory if it does not exists
 func (fs *GCSFs) CheckRootPath(username string, uid int, gid int) bool {
 	// we need a local directory for temporary files
-	osFs := NewOsFs(fs.ConnectionID(), fs.localTempDir, "")
+	osFs := NewOsFs(fs.ConnectionID(), fs.localTempDir, "", uid, gid)
 	return osFs.CheckRootPath(username, uid, gid)
 }
 

--- a/internal/vfs/httpfs.go
+++ b/internal/vfs/httpfs.go
@@ -527,7 +527,7 @@ func (*HTTPFs) IsNotSupported(err error) bool {
 // CheckRootPath creates the specified local root directory if it does not exists
 func (fs *HTTPFs) CheckRootPath(username string, uid int, gid int) bool {
 	// we need a local directory for temporary files
-	osFs := NewOsFs(fs.ConnectionID(), fs.localTempDir, "")
+	osFs := NewOsFs(fs.ConnectionID(), fs.localTempDir, "", uid, gid)
 	return osFs.CheckRootPath(username, uid, gid)
 }
 

--- a/internal/vfs/osfs_fallback.go
+++ b/internal/vfs/osfs_fallback.go
@@ -1,0 +1,10 @@
+//go:build !linux
+// +build !linux
+
+package vfs
+
+func (fs *OsFs) setuid() {
+}
+
+func (fs *OsFs) unsetuid() {
+}

--- a/internal/vfs/osfs_linux.go
+++ b/internal/vfs/osfs_linux.go
@@ -1,0 +1,55 @@
+//go:build linux
+// +build linux
+
+package vfs
+
+import (
+	"runtime"
+	"syscall"
+
+	"github.com/drakkan/sftpgo/v2/internal/logger"
+)
+
+func (fs *OsFs) setuid() {
+	if fs.uid <= 0 && fs.gid <= 0 {
+		return
+	}
+
+	if syscall.Geteuid() > 0 {
+		return
+	}
+
+	runtime.LockOSThread()
+
+	if fs.gid != syscall.Getegid() && fs.gid > 0 {
+		if err := syscall.Setegid(fs.gid); err != nil {
+			fsLog(fs, logger.LevelError, "could not call setegid: %q", err)
+		}
+	}
+
+	if fs.uid != syscall.Geteuid() && fs.uid > 0 {
+		if err := syscall.Seteuid(fs.uid); err != nil {
+			fsLog(fs, logger.LevelError, "could not call seteuid: %q", err)
+		}
+	}
+}
+
+func (fs *OsFs) unsetuid() {
+	if fs.uid <= 0 && fs.gid <= 0 {
+		return
+	}
+
+	if syscall.Getuid() != syscall.Geteuid() && fs.uid > 0 {
+		if err := syscall.Seteuid(syscall.Getuid()); err != nil {
+			fsLog(fs, logger.LevelError, "could not call seteuid: %q", err)
+		}
+	}
+
+	if syscall.Getgid() != syscall.Getegid() && fs.gid > 0 {
+		if err := syscall.Setegid(syscall.Getgid()); err != nil {
+			fsLog(fs, logger.LevelError, "could not call setegid: %q", err)
+		}
+	}
+
+	runtime.UnlockOSThread()
+}

--- a/internal/vfs/s3fs.go
+++ b/internal/vfs/s3fs.go
@@ -502,7 +502,7 @@ func (*S3Fs) IsNotSupported(err error) bool {
 // CheckRootPath creates the specified local root directory if it does not exists
 func (fs *S3Fs) CheckRootPath(username string, uid int, gid int) bool {
 	// we need a local directory for temporary files
-	osFs := NewOsFs(fs.ConnectionID(), fs.localTempDir, "")
+	osFs := NewOsFs(fs.ConnectionID(), fs.localTempDir, "", uid, gid)
 	return osFs.CheckRootPath(username, uid, gid)
 }
 

--- a/internal/vfs/sftpfs.go
+++ b/internal/vfs/sftpfs.go
@@ -573,7 +573,7 @@ func (*SFTPFs) IsNotSupported(err error) bool {
 // CheckRootPath creates the specified local root directory if it does not exists
 func (fs *SFTPFs) CheckRootPath(username string, uid int, gid int) bool {
 	// local directory for temporary files in buffer mode
-	osFs := NewOsFs(fs.ConnectionID(), fs.localTempDir, "")
+	osFs := NewOsFs(fs.ConnectionID(), fs.localTempDir, "", uid, gid)
 	osFs.CheckRootPath(username, uid, gid)
 	if fs.config.Prefix == "/" {
 		return true

--- a/internal/vfs/vfs.go
+++ b/internal/vfs/vfs.go
@@ -23,7 +23,6 @@ import (
 	"os"
 	"path"
 	"path/filepath"
-	"runtime"
 	"strings"
 	"time"
 
@@ -810,22 +809,6 @@ func HasOpenRWSupport(fs Fs) bool {
 // IsLocalOrCryptoFs returns true if fs is local or local encrypted
 func IsLocalOrCryptoFs(fs Fs) bool {
 	return IsLocalOsFs(fs) || IsCryptOsFs(fs)
-}
-
-// SetPathPermissions calls fs.Chown.
-// It does nothing for local filesystem on windows
-func SetPathPermissions(fs Fs, path string, uid int, gid int) {
-	if uid == -1 && gid == -1 {
-		return
-	}
-	if IsLocalOsFs(fs) {
-		if runtime.GOOS == "windows" {
-			return
-		}
-	}
-	if err := fs.Chown(path, uid, gid); err != nil {
-		fsLog(fs, logger.LevelWarn, "error chowning path %v: %v", path, err)
-	}
 }
 
 func updateFileInfoModTime(storageID, objectPath string, info *FileInfo) (*FileInfo, error) {

--- a/internal/webdavd/handler.go
+++ b/internal/webdavd/handler.go
@@ -221,8 +221,6 @@ func (c *Connection) handleUploadToNewFile(fs vfs.Fs, resolvedPath, filePath, re
 		return nil, c.GetFsError(fs, err)
 	}
 
-	vfs.SetPathPermissions(fs, filePath, c.User.GetUID(), c.User.GetGID())
-
 	// we can get an error only for resume
 	maxWriteSize, _ := c.GetMaxWriteSize(diskQuota, false, 0, fs.IsUploadResumeSupported())
 
@@ -283,8 +281,6 @@ func (c *Connection) handleUploadToExistingFile(fs vfs.Fs, resolvedPath, filePat
 		initialSize = fileSize
 		truncatedSize = fileSize
 	}
-
-	vfs.SetPathPermissions(fs, filePath, c.User.GetUID(), c.User.GetGID())
 
 	baseTransfer := common.NewBaseTransfer(file, c.BaseConnection, cancelFn, resolvedPath, filePath, requestPath,
 		common.TransferUpload, 0, initialSize, maxWriteSize, truncatedSize, false, fs, transferQuota)

--- a/internal/webdavd/internal_test.go
+++ b/internal/webdavd/internal_test.go
@@ -326,7 +326,7 @@ func (fs *MockOsFs) GetMimeType(name string) (string, error) {
 
 func newMockOsFs(atomicUpload bool, connectionID, rootDir string, reader *pipeat.PipeReaderAt, err error) vfs.Fs {
 	return &MockOsFs{
-		Fs:                      vfs.NewOsFs(connectionID, rootDir, ""),
+		Fs:                      vfs.NewOsFs(connectionID, rootDir, "", 0, 0),
 		isAtomicUploadSupported: atomicUpload,
 		reader:                  reader,
 		err:                     err,
@@ -483,7 +483,7 @@ func TestResolvePathErrors(t *testing.T) {
 	}
 	user.Permissions = make(map[string][]string)
 	user.Permissions["/"] = []string{dataprovider.PermAny}
-	fs := vfs.NewOsFs("connID", user.HomeDir, "")
+	fs := vfs.NewOsFs("connID", user.HomeDir, "", 0, 0)
 	connection := &Connection{
 		BaseConnection: common.NewBaseConnection(fs.ConnectionID(), common.ProtocolWebDAV, "", "", user),
 	}
@@ -516,7 +516,7 @@ func TestResolvePathErrors(t *testing.T) {
 	if runtime.GOOS != "windows" {
 		user.HomeDir = filepath.Clean(os.TempDir())
 		connection.User = user
-		fs := vfs.NewOsFs("connID", connection.User.HomeDir, "")
+		fs := vfs.NewOsFs("connID", connection.User.HomeDir, "", 0, 0)
 		subDir := "sub"
 		testTxtFile := "file.txt"
 		err = os.MkdirAll(filepath.Join(os.TempDir(), subDir, subDir), os.ModePerm)
@@ -554,7 +554,7 @@ func TestFileAccessErrors(t *testing.T) {
 	}
 	user.Permissions = make(map[string][]string)
 	user.Permissions["/"] = []string{dataprovider.PermAny}
-	fs := vfs.NewOsFs("connID", user.HomeDir, "")
+	fs := vfs.NewOsFs("connID", user.HomeDir, "", 0, 0)
 	connection := &Connection{
 		BaseConnection: common.NewBaseConnection(fs.ConnectionID(), common.ProtocolWebDAV, "", "", user),
 	}
@@ -646,7 +646,7 @@ func TestContentType(t *testing.T) {
 	}
 	user.Permissions = make(map[string][]string)
 	user.Permissions["/"] = []string{dataprovider.PermAny}
-	fs := vfs.NewOsFs("connID", user.HomeDir, "")
+	fs := vfs.NewOsFs("connID", user.HomeDir, "", 0, 0)
 	connection := &Connection{
 		BaseConnection: common.NewBaseConnection(fs.ConnectionID(), common.ProtocolWebDAV, "", "", user),
 	}
@@ -673,7 +673,7 @@ func TestContentType(t *testing.T) {
 	baseTransfer = common.NewBaseTransfer(nil, connection.BaseConnection, nil, testFilePath, testFilePath, testFile+".unknown1",
 		common.TransferDownload, 0, 0, 0, 0, false, fs, dataprovider.TransferQuota{})
 	davFile = newWebDavFile(baseTransfer, nil, nil)
-	davFile.Fs = vfs.NewOsFs("id", user.HomeDir, "")
+	davFile.Fs = vfs.NewOsFs("id", user.HomeDir, "", 0, 0)
 	fi, err = davFile.Stat()
 	if assert.NoError(t, err) {
 		ctype, err := fi.(*webDavFileInfo).ContentType(ctx)
@@ -686,7 +686,7 @@ func TestContentType(t *testing.T) {
 	baseTransfer = common.NewBaseTransfer(nil, connection.BaseConnection, nil, testFilePath, testFilePath, testFile,
 		common.TransferDownload, 0, 0, 0, 0, false, fs, dataprovider.TransferQuota{})
 	davFile = newWebDavFile(baseTransfer, nil, nil)
-	davFile.Fs = vfs.NewOsFs("id", user.HomeDir, "")
+	davFile.Fs = vfs.NewOsFs("id", user.HomeDir, "", 0, 0)
 	fi, err = davFile.Stat()
 	if assert.NoError(t, err) {
 		ctype, err := fi.(*webDavFileInfo).ContentType(ctx)
@@ -701,7 +701,7 @@ func TestContentType(t *testing.T) {
 		baseTransfer = common.NewBaseTransfer(nil, connection.BaseConnection, nil, testFilePath, testFilePath, testFile+".custom",
 			common.TransferDownload, 0, 0, 0, 0, false, fs, dataprovider.TransferQuota{})
 		davFile = newWebDavFile(baseTransfer, nil, nil)
-		davFile.Fs = vfs.NewOsFs("id", user.HomeDir, "")
+		davFile.Fs = vfs.NewOsFs("id", user.HomeDir, "", 0, 0)
 		fi, err = davFile.Stat()
 		if assert.NoError(t, err) {
 			ctype, err := fi.(*webDavFileInfo).ContentType(ctx)
@@ -755,7 +755,7 @@ func TestTransferReadWriteErrors(t *testing.T) {
 	}
 	user.Permissions = make(map[string][]string)
 	user.Permissions["/"] = []string{dataprovider.PermAny}
-	fs := vfs.NewOsFs("connID", user.HomeDir, "")
+	fs := vfs.NewOsFs("connID", user.HomeDir, "", 0, 0)
 	connection := &Connection{
 		BaseConnection: common.NewBaseConnection(fs.ConnectionID(), common.ProtocolWebDAV, "", "", user),
 	}
@@ -911,7 +911,7 @@ func TestTransferSeek(t *testing.T) {
 	assert.True(t, fs.IsNotExist(err))
 	davFile.Connection.RemoveTransfer(davFile.BaseTransfer)
 
-	fs = vfs.NewOsFs(fs.ConnectionID(), user.GetHomeDir(), "")
+	fs = vfs.NewOsFs(fs.ConnectionID(), user.GetHomeDir(), "", 0, 0)
 	baseTransfer = common.NewBaseTransfer(nil, connection.BaseConnection, nil, testFilePath+"1", testFilePath+"1", testFile,
 		common.TransferDownload, 0, 0, 0, 0, false, fs, dataprovider.TransferQuota{AllowedTotalSize: 100})
 	davFile = newWebDavFile(baseTransfer, nil, nil)

--- a/internal/webdavd/webdavd_test.go
+++ b/internal/webdavd/webdavd_test.go
@@ -1497,7 +1497,7 @@ func TestMaxConnections(t *testing.T) {
 	client := getWebDavClient(user, true, nil)
 	assert.NoError(t, checkBasicFunc(client))
 	// now add a fake connection
-	fs := vfs.NewOsFs("id", os.TempDir(), "")
+	fs := vfs.NewOsFs("id", os.TempDir(), "", 0, 0)
 	connection := &webdavd.Connection{
 		BaseConnection: common.NewBaseConnection(fs.ConnectionID(), common.ProtocolWebDAV, "", "", user),
 	}
@@ -1576,7 +1576,7 @@ func TestMaxSessions(t *testing.T) {
 	client := getWebDavClient(user, false, nil)
 	assert.NoError(t, checkBasicFunc(client))
 	// now add a fake connection
-	fs := vfs.NewOsFs("id", os.TempDir(), "")
+	fs := vfs.NewOsFs("id", os.TempDir(), "", 0, 0)
 	connection := &webdavd.Connection{
 		BaseConnection: common.NewBaseConnection(fs.ConnectionID(), common.ProtocolWebDAV, "", "", user),
 	}


### PR DESCRIPTION
This PR proposes to change the behaviour of setting a uid/gid for a user, if sftpgo is run as root. If a user would create or modify a file, we act as the uid/gid to execute the modification, instead of acting as root and chowning the resulting file later. It is implemented in the virtual file system layer by calling syscall.Seteuid and syscall.Setegid before the operations. 

The main benefit is that file permissions on the underlying file system will be honoured, as well as the virtual permissions that are checked by sftpgo itself. Only for creating the top user directory, we'll still act as root to ensure its existence.

The only exception is the ScanQuota function for virtual folders that is ran as root if triggered by an event, but that operation only reads files so it should be fine.

In case you would consider to merge this, I'm willing to invest time in implementing secondary groups as well.