### PR TITLE
WebDAV when user authentication fails.

### DIFF
--- a/internal/webdavd/server.go
+++ b/internal/webdavd/server.go
@@ -301,7 +301,12 @@ func (s *webDavServer) authenticate(r *http.Request, ip string) (dataprovider.Us
 				return cachedUser.User, true, cachedUser.LockSystem, loginMethod, nil
 			}
 			updateLoginMetrics(&cachedUser.User, ip, loginMethod, dataprovider.ErrInvalidCredentials)
-			return user, false, nil, loginMethod, dataprovider.ErrInvalidCredentials
+
+			if cachedUser.User.HasExternalAuth() {
+				dataprovider.RemoveCachedWebDAVUser(username)
+			} else {
+				return user, false, nil, loginMethod, dataprovider.ErrInvalidCredentials
+			}
 		}
 	}
 	user, loginMethod, err = dataprovider.CheckCompositeCredentials(username, password, ip, loginMethod,


### PR DESCRIPTION
When the password of a user who uses external validation is changed, if the user attempts to validate using the new password, it may fail due to WebDAV caching the user information. In this case, should clear the cache and perform external validation again.

