### PR TITLE
docs: add info about IRSA for S3 authn

### DIFF
--- a/docs/s3.md
+++ b/docs/s3.md
@@ -7,6 +7,8 @@ AWS SDK has different options for credentials. We support:
 1. Providing [Access Keys](https://docs.aws.amazon.com/general/latest/gr/aws-sec-cred-types.html#access-keys-and-secret-access-keys).
 2. Use IAM roles for Amazon EC2
 3. Use IAM roles for tasks if your application uses an ECS task definition
+4. Utilizing [IAM roles](https://docs.aws.amazon.com/eks/latest/userguide/iam-roles-for-service-accounts.html) for service accounts (IRSA) if you operate sftpgo atop AWS EKS.
+5. Assuming specific IAM role by setting its ARN
 
 So, you need to provide access keys to activate option 1, or leave them blank to use the other ways to specify credentials.
 


### PR DESCRIPTION
Hello 👋 

Looks like IAM roles for service accounts (OIDC, SDK uses k8s service account token to assume specified role with `sts:AssumeRoleWithWebIdentity`) are also supported by current code, so I just wanted to mention that in docs. I was wondering if that gonna work on not :)