### PR TITLE
Adding pre-lsdir sync Fs event

### DIFF
--- a/internal/common/common.go
+++ b/internal/common/common.go
@@ -52,6 +52,7 @@ const (
 	renameLogSender        = "Rename"
 	rmdirLogSender         = "Rmdir"
 	mkdirLogSender         = "Mkdir"
+	lsdirLogSender         = "Lsdir"
 	symlinkLogSender       = "Symlink"
 	removeLogSender        = "Remove"
 	chownLogSender         = "Chown"
@@ -70,6 +71,7 @@ const (
 	// Pre-upload action name
 	OperationPreUpload = "pre-upload"
 	operationPreDelete = "pre-delete"
+	operationPreLsdir  = "pre-lsdir"
 	operationRename    = "rename"
 	operationMkdir     = "mkdir"
 	operationRmdir     = "rmdir"

--- a/internal/common/connection.go
+++ b/internal/common/connection.go
@@ -301,15 +301,27 @@ func (c *BaseConnection) ListDir(virtualPath string) ([]os.FileInfo, error) {
 	if !c.User.HasPerm(dataprovider.PermListItems, virtualPath) {
 		return nil, c.GetPermissionDeniedError()
 	}
+	println("listing dir >>>>>>>>>>>>>>>>")
 	fs, fsPath, err := c.GetFsAndResolvedPath(virtualPath)
 	if err != nil {
 		return nil, err
 	}
+	_, err = ExecutePreAction(c, operationPreLsdir, fsPath, virtualPath, 0, 0)
+	if err != nil {
+		c.Log(logger.LevelDebug, "list for dir %q denied by pre action: %v", virtualPath, err)
+		return nil, c.GetPermissionDeniedError()
+	}
+	startTime := time.Now()
 	files, err := fs.ReadDir(fsPath)
 	if err != nil {
 		c.Log(logger.LevelDebug, "error listing directory: %+v", err)
 		return nil, c.GetFsError(fs, err)
 	}
+	elapsed := time.Since(startTime).Nanoseconds() / 1000000
+
+	logger.CommandLog(lsdirLogSender, fsPath, "", c.User.Username, "", c.ID, c.protocol, -1, -1, "", "", "", -1,
+		c.localAddr, c.remoteAddr, elapsed)
+
 	return c.User.FilterListDir(files, virtualPath), nil
 }
 
@@ -410,6 +422,7 @@ func (c *BaseConnection) RemoveFile(fs vfs.Fs, fsPath, virtualPath string, info 
 		return c.GetPermissionDeniedError()
 	}
 	updateQuota := true
+	println("deleting file >>>>>>>>>>>>>>>>")
 	startTime := time.Now()
 	if err := fs.Remove(fsPath, false); err != nil {
 		if status > 0 && fs.IsNotExist(err) {
@@ -492,6 +505,7 @@ func (c *BaseConnection) RemoveDir(virtualPath string) error {
 		c.Log(logger.LevelError, "cannot remove %q is not a directory", fsPath)
 		return c.GetGenericError(nil)
 	}
+	println("deleting dir >>>>>>>>>>>>>>>>")
 
 	startTime := time.Now()
 	if err := fs.Remove(fsPath, true); err != nil {

--- a/internal/common/connection.go
+++ b/internal/common/connection.go
@@ -301,7 +301,6 @@ func (c *BaseConnection) ListDir(virtualPath string) ([]os.FileInfo, error) {
 	if !c.User.HasPerm(dataprovider.PermListItems, virtualPath) {
 		return nil, c.GetPermissionDeniedError()
 	}
-	println("listing dir >>>>>>>>>>>>>>>>")
 	fs, fsPath, err := c.GetFsAndResolvedPath(virtualPath)
 	if err != nil {
 		return nil, err
@@ -422,7 +421,6 @@ func (c *BaseConnection) RemoveFile(fs vfs.Fs, fsPath, virtualPath string, info 
 		return c.GetPermissionDeniedError()
 	}
 	updateQuota := true
-	println("deleting file >>>>>>>>>>>>>>>>")
 	startTime := time.Now()
 	if err := fs.Remove(fsPath, false); err != nil {
 		if status > 0 && fs.IsNotExist(err) {
@@ -505,7 +503,6 @@ func (c *BaseConnection) RemoveDir(virtualPath string) error {
 		c.Log(logger.LevelError, "cannot remove %q is not a directory", fsPath)
 		return c.GetGenericError(nil)
 	}
-	println("deleting dir >>>>>>>>>>>>>>>>")
 
 	startTime := time.Now()
 	if err := fs.Remove(fsPath, true); err != nil {

--- a/internal/dataprovider/eventrule.go
+++ b/internal/dataprovider/eventrule.go
@@ -189,7 +189,7 @@ func getFsActionTypeAsString(value int) string {
 var (
 	// SupportedFsEvents defines the supported filesystem events
 	SupportedFsEvents = []string{"upload", "pre-upload", "first-upload", "download", "pre-download",
-		"first-download", "delete", "pre-delete", "rename", "mkdir", "rmdir", "copy", "ssh_cmd"}
+		"first-download", "delete", "pre-delete", "rename", "mkdir", "rmdir", "pre-lsdir", "copy", "ssh_cmd"}
 	// SupportedProviderEvents defines the supported provider events
 	SupportedProviderEvents = []string{operationAdd, operationUpdate, operationDelete}
 	// SupportedRuleConditionProtocols defines the supported protcols for rule conditions
@@ -200,8 +200,8 @@ var (
 		actionObjectAdmin, actionObjectAPIKey, actionObjectShare, actionObjectEventRule, actionObjectEventAction}
 	// SupportedHTTPActionMethods defines the supported methods for HTTP actions
 	SupportedHTTPActionMethods = []string{http.MethodPost, http.MethodGet, http.MethodPut}
-	allowedSyncFsEvents        = []string{"upload", "pre-upload", "pre-download", "pre-delete"}
-	mandatorySyncFsEvents      = []string{"pre-upload", "pre-download", "pre-delete"}
+	allowedSyncFsEvents        = []string{"upload", "pre-upload", "pre-download", "pre-delete", "pre-lsdir"}
+	mandatorySyncFsEvents      = []string{"pre-upload", "pre-download", "pre-delete", "pre-lsdir"}
 )
 
 // enum mappings


### PR DESCRIPTION
Adding to the hooks system new `pre-lsdir` as mandatory Sync Fs Event to enable web-hook or external script execution before reading directory content from Fs.   