### PR TITLE
check for multiple inverse matches

### DIFF
--- a/internal/common/eventmanager.go
+++ b/internal/common/eventmanager.go
@@ -1159,7 +1159,7 @@ func checkEventConditionPatterns(name string, patterns []dataprovider.ConditionP
 				return false
 			}
 		} else if checkEventConditionPattern(p, name) {
-			matches = true
+			return true
 		}
 	}
 	return matches

--- a/internal/common/eventmanager.go
+++ b/internal/common/eventmanager.go
@@ -1170,10 +1170,8 @@ func checkEventGroupConditionPatters(groups []sdk.GroupMapping, patterns []datap
 		return true
 	}
 	for _, group := range groups {
-		for _, p := range patterns {
-			if checkEventConditionPattern(p, group.Name) {
-				return true
-			}
+		if checkEventConditionPatterns(group.Name, patterns) {
+			return true
 		}
 	}
 

--- a/internal/common/eventmanager.go
+++ b/internal/common/eventmanager.go
@@ -1149,13 +1149,20 @@ func checkEventConditionPatterns(name string, patterns []dataprovider.ConditionP
 	if len(patterns) == 0 {
 		return true
 	}
+	matches := false
 	for _, p := range patterns {
-		if checkEventConditionPattern(p, name) {
-			return true
+		// assume, that multiple InverseMatches are set
+		if p.InverseMatch {
+			if checkEventConditionPattern(p, name) {
+				matches = true
+			} else {
+				return false
+			}
+		} else if checkEventConditionPattern(p, name) {
+			matches = true
 		}
 	}
-
-	return false
+	return matches
 }
 
 func checkEventGroupConditionPatters(groups []sdk.GroupMapping, patterns []dataprovider.ConditionPattern) bool {

--- a/internal/common/eventmanager.go
+++ b/internal/common/eventmanager.go
@@ -331,7 +331,7 @@ func (*eventRulesContainer) checkFsEventMatch(conditions *dataprovider.EventCond
 	if !checkEventConditionPatterns(params.Role, conditions.Options.RoleNames) {
 		return false
 	}
-	if !checkEventGroupConditionPatters(params.Groups, conditions.Options.GroupNames) {
+	if !checkEventGroupConditionPatterns(params.Groups, conditions.Options.GroupNames) {
 		return false
 	}
 	if !checkEventConditionPatterns(params.VirtualPath, conditions.Options.FsPaths) {
@@ -1138,7 +1138,7 @@ func checkUserConditionOptions(user *dataprovider.User, conditions *dataprovider
 	if !checkEventConditionPatterns(user.Role, conditions.RoleNames) {
 		return false
 	}
-	if !checkEventGroupConditionPatters(user.Groups, conditions.GroupNames) {
+	if !checkEventGroupConditionPatterns(user.Groups, conditions.GroupNames) {
 		return false
 	}
 	return true
@@ -1165,7 +1165,7 @@ func checkEventConditionPatterns(name string, patterns []dataprovider.ConditionP
 	return matches
 }
 
-func checkEventGroupConditionPatters(groups []sdk.GroupMapping, patterns []dataprovider.ConditionPattern) bool {
+func checkEventGroupConditionPatterns(groups []sdk.GroupMapping, patterns []dataprovider.ConditionPattern) bool {
 	if len(patterns) == 0 {
 		return true
 	}

--- a/internal/common/eventmanager_test.go
+++ b/internal/common/eventmanager_test.go
@@ -355,6 +355,55 @@ func TestDoubleStarMatching(t *testing.T) {
 	assert.False(t, res)
 	res = checkEventConditionPattern(c, "/mydir/sub/dir/a.txt")
 	assert.True(t, res)
+
+	c.InverseMatch = true
+	assert.True(t, checkEventConditionPattern(c, "/mydir"))
+	assert.True(t, checkEventConditionPattern(c, "/mydirname/f.txt"))
+	assert.True(t, checkEventConditionPattern(c, "/mydir/sub"))
+	assert.True(t, checkEventConditionPattern(c, "/mydir/sub/dir"))
+	assert.False(t, checkEventConditionPattern(c, "/mydir/sub/dir/a.txt"))
+}
+
+func TestMutlipleDoubleStarMatching(t *testing.T) {
+	patterns := []dataprovider.ConditionPattern{
+		{
+			Pattern:      "/**/*.txt",
+			InverseMatch: false,
+		},
+		{
+			Pattern:      "/**/*.tmp",
+			InverseMatch: false,
+		},
+	}
+	assert.False(t, checkEventConditionPatterns("/mydir", patterns))
+	assert.True(t, checkEventConditionPatterns("/mydir/test.tmp", patterns))
+	assert.True(t, checkEventConditionPatterns("/mydir/test.txt", patterns))
+	assert.False(t, checkEventConditionPatterns("/mydir/test.csv", patterns))
+	assert.False(t, checkEventConditionPatterns("/mydir/sub", patterns))
+	assert.True(t, checkEventConditionPatterns("/mydir/sub/test.tmp", patterns))
+	assert.True(t, checkEventConditionPatterns("/mydir/sub/test.txt", patterns))
+	assert.False(t, checkEventConditionPatterns("/mydir/sub/test.csv", patterns))
+}
+
+func TestMultipleDoubleStarMatchingInverse(t *testing.T) {
+	patterns := []dataprovider.ConditionPattern{
+		{
+			Pattern:      "/**/*.txt",
+			InverseMatch: true,
+		},
+		{
+			Pattern:      "/**/*.tmp",
+			InverseMatch: true,
+		},
+	}
+	assert.True(t, checkEventConditionPatterns("/mydir", patterns))
+	assert.False(t, checkEventConditionPatterns("/mydir/test.tmp", patterns))
+	assert.False(t, checkEventConditionPatterns("/mydir/test.txt", patterns))
+	assert.True(t, checkEventConditionPatterns("/mydir/test.csv", patterns))
+	assert.True(t, checkEventConditionPatterns("/mydir/sub", patterns))
+	assert.False(t, checkEventConditionPatterns("/mydir/sub/test.tmp", patterns))
+	assert.False(t, checkEventConditionPatterns("/mydir/sub/test.txt", patterns))
+	assert.True(t, checkEventConditionPatterns("/mydir/sub/test.csv", patterns))
 }
 
 func TestEventManager(t *testing.T) {


### PR DESCRIPTION
## Current behaviour
The check `checkEventConditionPatterns` returns after first match is true, which doesn't allow to check multiple wildcards inverse. 

## New behaviour
This change allows in the event rules to set multiple path filters with **inverse matches**. 
Which allows for matching to any kind of file except for those inverse matches (acts as an exclusions list).
![image](https://github.com/drakkan/sftpgo/assets/7965357/8abd1abc-8932-47eb-9c26-b0799ed8d063)
All tests on the eventmanager_test.go passed.

## Known limitations
Probably doesn't work with mixed path filters. Which I think does not make sense anyway, because a matching pattern always exclude any other inverse matches.

## Changes

* update function checkEventConditionPatterns for multiple inverse patterns
  * Use the _matches_ variable to keep track of the state if condition matches pattern. 
* extend TestDoubleStarMatching with inverse flag
* write test for multiple douple start matches, also for  inverse matches