### PR TITLE
provider: support for username and password file

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -324,7 +324,9 @@ func Init() {
 			Host:               "",
 			Port:               0,
 			Username:           "",
+			UsernameFile:       "",
 			Password:           "",
+			PasswordFile:       "",
 			ConnectionString:   "",
 			SQLTablesPrefix:    "",
 			SSLMode:            0,
@@ -2082,7 +2084,9 @@ func setViperDefaults() {
 	viper.SetDefault("data_provider.host", globalConf.ProviderConf.Host)
 	viper.SetDefault("data_provider.port", globalConf.ProviderConf.Port)
 	viper.SetDefault("data_provider.username", globalConf.ProviderConf.Username)
+	viper.SetDefault("data_provider.username_file", globalConf.ProviderConf.UsernameFile)
 	viper.SetDefault("data_provider.password", globalConf.ProviderConf.Password)
+	viper.SetDefault("data_provider.password_file", globalConf.ProviderConf.PasswordFile)
 	viper.SetDefault("data_provider.sslmode", globalConf.ProviderConf.SSLMode)
 	viper.SetDefault("data_provider.disable_sni", globalConf.ProviderConf.DisableSNI)
 	viper.SetDefault("data_provider.target_session_attrs", globalConf.ProviderConf.TargetSessionAttrs)

--- a/internal/dataprovider/dataprovider.go
+++ b/internal/dataprovider/dataprovider.go
@@ -355,8 +355,10 @@ type Config struct {
 	Port int `json:"port" mapstructure:"port"`
 	// Database username
 	Username string `json:"username" mapstructure:"username"`
+	UsernameFile string `json:"username_file" mapstructure:"username_file"`
 	// Database password
 	Password string `json:"password" mapstructure:"password"`
+	PasswordFile string `json:"password_file" mapstructure:"password_file"`
 	// Used for drivers mysql and postgresql.
 	// 0 disable SSL/TLS connections.
 	// 1 require ssl.
@@ -874,6 +876,22 @@ func Initialize(cnf Config, basePath string, checkAdmins bool) error {
 	checkSharedMode()
 	config.Actions.ExecuteOn = util.RemoveDuplicates(config.Actions.ExecuteOn, true)
 	config.Actions.ExecuteFor = util.RemoveDuplicates(config.Actions.ExecuteFor, true)
+
+	if config.Username == "" && config.UsernameFile != "" {
+		user, err := os.ReadFile(config.UsernameFile)
+		if err != nil {
+			return err
+		}
+		config.Username = string(user)
+	}
+
+	if config.Password == "" && config.PasswordFile != "" {
+		password, err := os.ReadFile(config.PasswordFile)
+		if err != nil {
+			return err
+		}
+		config.Password = string(password)
+	}
 
 	cnf.BackupsPath = getConfigPath(cnf.BackupsPath, basePath)
 	if cnf.BackupsPath == "" {


### PR DESCRIPTION
This Pull Request introduces a feature that allows a file to be mounted for the data provider’s username and password. This is especially useful when using Docker secrets.

config:
```json
{
  "data_provider": {
    "username_file": "/path/to/file",
    "password_file": "/path/to/file",
  }
}
```

env:
```env
SFTPGO_DATA_PROVIDER__USERNAME_FILE="/path/to/file"
SFTPGO_DATA_PROVIDER__PASSWORD_FILE="/path/to/file"
```
