### PR TITLE
defender: implement logging of events and bans

### DIFF
--- a/docs/full-configuration.md
+++ b/docs/full-configuration.md
@@ -103,6 +103,7 @@ The configuration file contains the following sections:
     - `observation_time`, integer. Defines the time window, in minutes, for tracking client errors. A host is banned if it has exceeded the defined threshold during the last observation time minutes. Default: `30`.
     - `entries_soft_limit`, integer. Ignored for `provider` driver. Default: `100`.
     - `entries_hard_limit`, integer. The number of banned IPs and host scores kept in memory will vary between the soft and hard limit for `memory` driver. If you use the `provider` driver, this setting will limit the number of entries to return when you ask for the entire host list from the defender. Default: `150`.
+    - `log_events`, boolean. Set to true if defender events and banned IPs should be logged. Default: `false`.
   - `rate_limiters`, list of structs containing the rate limiters configuration. Take a look [here](./rate-limiting.md) for more details. Each struct has the following fields:
     - `average`, integer. Average defines the maximum rate allowed. 0 means disabled. Default: 0
     - `period`, integer. Period defines the period as milliseconds. The rate is actually defined by dividing average by period Default: 1000 (1 second).

--- a/docs/full-configuration.md
+++ b/docs/full-configuration.md
@@ -103,7 +103,6 @@ The configuration file contains the following sections:
     - `observation_time`, integer. Defines the time window, in minutes, for tracking client errors. A host is banned if it has exceeded the defined threshold during the last observation time minutes. Default: `30`.
     - `entries_soft_limit`, integer. Ignored for `provider` driver. Default: `100`.
     - `entries_hard_limit`, integer. The number of banned IPs and host scores kept in memory will vary between the soft and hard limit for `memory` driver. If you use the `provider` driver, this setting will limit the number of entries to return when you ask for the entire host list from the defender. Default: `150`.
-    - `log_events`, boolean. Set to true if defender events and banned IPs should be logged. Default: `false`.
   - `rate_limiters`, list of structs containing the rate limiters configuration. Take a look [here](./rate-limiting.md) for more details. Each struct has the following fields:
     - `average`, integer. Average defines the maximum rate allowed. 0 means disabled. Default: 0
     - `period`, integer. Period defines the period as milliseconds. The rate is actually defined by dividing average by period Default: 1000 (1 second).

--- a/internal/common/defender.go
+++ b/internal/common/defender.go
@@ -90,8 +90,6 @@ type DefenderConfig struct {
 	// to return when you request for the entire host list from the defender
 	EntriesSoftLimit int `json:"entries_soft_limit" mapstructure:"entries_soft_limit"`
 	EntriesHardLimit int `json:"entries_hard_limit" mapstructure:"entries_hard_limit"`
-	// LogEvents controls if Defender events should be logged
-	LogEvents bool `json:"log_events" mapstructure:"log_events"`
 }
 
 type baseDefender struct {
@@ -135,18 +133,15 @@ func (d *baseDefender) getScore(event HostEvent) int {
 	return score
 }
 
+// logEvent do log an defender event which modifies the score of an host
 func (d *baseDefender) logEvent(ip, protocol string, event HostEvent, totalScore int) {
-	if !d.config.LogEvents {
-		return
-	}
-
 	// ignore events which do not change the host score
 	eventScore := d.getScore(event)
 	if eventScore == 0 {
 		return
 	}
 
-	logger.GetLogger().Info().
+	logger.GetLogger().Debug().
 		Timestamp().
 		Str("sender", "defender").
 		Str("client_ip", ip).
@@ -157,11 +152,8 @@ func (d *baseDefender) logEvent(ip, protocol string, event HostEvent, totalScore
 		Send()
 }
 
+// logBan do log a ban of an host due to a too high host score
 func (d *baseDefender) logBan(ip, protocol string) {
-	if !d.config.LogEvents {
-		return
-	}
-
 	logger.GetLogger().Info().
 		Timestamp().
 		Str("sender", "defender").

--- a/internal/common/defenderdb.go
+++ b/internal/common/defenderdb.go
@@ -100,7 +100,9 @@ func (d *dbDefender) AddEvent(ip, protocol string, event HostEvent) {
 	if err != nil {
 		return
 	}
+	d.baseDefender.logEvent(ip, protocol, event, host.Score)
 	if host.Score > d.config.Threshold {
+		d.baseDefender.logBan(ip, protocol)
 		banTime := time.Now().Add(time.Duration(d.config.BanTime) * time.Minute)
 		err = dataprovider.SetDefenderBanTime(ip, util.GetTimeAsMsSinceEpoch(banTime))
 		if err == nil {

--- a/internal/common/defendermem.go
+++ b/internal/common/defendermem.go
@@ -206,9 +206,11 @@ func (d *memoryDefender) AddEvent(ip, protocol string, event HostEvent) {
 				idx++
 			}
 		}
+		d.baseDefender.logEvent(ip, protocol, event, hs.TotalScore)
 
 		hs.Events = hs.Events[:idx]
 		if hs.TotalScore >= d.config.Threshold {
+			d.baseDefender.logBan(ip, protocol)
 			d.banned[ip] = time.Now().Add(time.Duration(d.config.BanTime) * time.Minute)
 			delete(d.hosts, ip)
 			d.cleanupBanned()
@@ -222,6 +224,7 @@ func (d *memoryDefender) AddEvent(ip, protocol string, event HostEvent) {
 			d.hosts[ip] = hs
 		}
 	} else {
+		d.baseDefender.logEvent(ip, protocol, event, ev.score)
 		d.hosts[ip] = hostScore{
 			TotalScore: ev.score,
 			Events:     []hostEvent{ev},


### PR DESCRIPTION
This PR implements optional log messages for defender events and the final ban of IPs. They can be enabled with the new config parameter `log_events: true` in the defender configuration struct.

Log Messages for invalid user and user with wrong credentials look like this:

```json
{"level":"info","time":"2023-12-19T10:04:39.093","sender":"defender","client_ip":"2a01:4f8::1","protocol":"FTP","event":"UserNotFound","increase_score_by":2,"score":2}
{"level":"info","time":"2023-12-19T10:04:45.360","sender":"defender","client_ip":"2a01:4f8::1","protocol":"FTP","event":"LoginFailed","increase_score_by":1,"score":3}
```

Log Messages when the score threshold is reached and the IP is banned:

```json
{"level":"info","time":"2023-12-19T10:07:53.768","sender":"defender","client_ip":"2a01:4f8::1","protocol":"FTP","event":"UserNotFound","increase_score_by":2,"score":15}
{"level":"info","time":"2023-12-19T10:07:53.768","sender":"defender","client_ip":"2a01:4f8::1","protocol":"FTP","event":"banned"}
```