### PR TITLE
fix using rsync if running sftpgo as non-root user

### DIFF
--- a/internal/sftpd/cmd_unix.go
+++ b/internal/sftpd/cmd_unix.go
@@ -18,12 +18,14 @@
 package sftpd
 
 import (
+	"os"
 	"os/exec"
 	"syscall"
 )
 
 func wrapCmd(cmd *exec.Cmd, uid, gid int) *exec.Cmd {
-	if uid > 0 || gid > 0 {
+	isCurrentUser := os.Getuid() == uid && os.Getgid() == gid
+	if (uid > 0 || gid > 0) && !isCurrentUser {
 		cmd.SysProcAttr = &syscall.SysProcAttr{}
 		cmd.SysProcAttr.Credential = &syscall.Credential{Uid: uint32(uid), Gid: uint32(gid)}
 	}


### PR DESCRIPTION
If sftpgo is already running as a non-root user and the UID/GID matches the current one, we can skip the syscall.