### PR TITLE
[Feature] allow multiple directory mappings (portable mode)

### DIFF
--- a/docs/portable-mode.md
+++ b/docs/portable-mode.md
@@ -1,6 +1,6 @@
 # Portable mode
 
-SFTPGo allows to share a single directory on demand using the `portable` subcommand:
+SFTPGo allows to share a single directory (and multiple virtual directory mappings) on demand using the `portable` subcommand:
 
 ```console
 sftpgo portable --help
@@ -174,6 +174,8 @@ Flags:
                                         path (default "/")
   -u, --username string                 Leave empty to use an auto generated
                                         value
+  -v, --virtual-directory strings       virtual directory mapping: "-v <host-path>[:<virtual-path>[:<permission>[;<permission>]]]".
+                                        available permissions: "*,list,download,upload,overwrite,delete,rename,create_dirs,create_symlinks,chmod,chown,chtimes"
       --webdav-cert string              Path to the certificate file for WebDAV
                                         over HTTPS
       --webdav-key string               Path to the key file for WebDAV over

--- a/internal/dataprovider/user.go
+++ b/internal/dataprovider/user.go
@@ -90,6 +90,7 @@ const (
 
 var (
 	errNoMatchingVirtualFolder = errors.New("no matching virtual folder found")
+	AvailablePermissions       = []string{PermAny, PermListItems, PermDownload, PermUpload, PermOverwrite, PermDelete, PermDeleteFiles, PermDeleteDirs, PermRename, PermRenameFiles, PermRenameDirs, PermCreateDirs, PermCreateSymlinks, PermChmod, PermChown, PermChtimes}
 	permsRenameAny             = []string{PermRename, PermRenameDirs, PermRenameFiles}
 	permsDeleteAny             = []string{PermDelete, PermDeleteDirs, PermDeleteFiles}
 )

--- a/internal/service/service.go
+++ b/internal/service/service.go
@@ -162,6 +162,13 @@ func (s *Service) initializeServices(disableAWSInstallationCode bool) error {
 	}
 
 	if s.PortableMode == 1 {
+		// add virtual folders to provider
+		for _, f := range s.PortableUser.VirtualFolders {
+			if err := dataprovider.AddFolder(&f.BaseVirtualFolder, dataprovider.ActionExecutorSystem, "", ""); err != nil {
+				return err
+			}
+		}
+
 		// create the user for portable mode
 		err = dataprovider.AddUser(&s.PortableUser, dataprovider.ActionExecutorSystem, "", "")
 		if err != nil {

--- a/internal/service/service.go
+++ b/internal/service/service.go
@@ -165,6 +165,7 @@ func (s *Service) initializeServices(disableAWSInstallationCode bool) error {
 		// add virtual folders to provider
 		for _, f := range s.PortableUser.VirtualFolders {
 			if err := dataprovider.AddFolder(&f.BaseVirtualFolder, dataprovider.ActionExecutorSystem, "", ""); err != nil {
+				logger.ErrorToConsole("error adding virtual folder %v for portable user: %v", f, err)
 				return err
 			}
 		}


### PR DESCRIPTION
From our perspective, it would be a useful addition to the portable mode if a user could have multiple (virtual) directories.

This PR enables the representation of multiple host paths in the user's directory by specifying one (or more) `-v <host-path>[:<virtual-path>[:<permission>[;<permission>]]]` for the sftp user.