### PR TITLE
SMTP: avoid loading templates if not enabled

### DIFF
--- a/internal/smtp/smtp.go
+++ b/internal/smtp/smtp.go
@@ -248,7 +248,7 @@ func (c *Config) loadTemplates(configDir string) error {
 	return nil
 }
 
-// Initialize initialized and validates the SMTP configuration
+// Initialize initializes and validates the SMTP configuration
 func (c *Config) Initialize(configDir string, isService bool) error {
 	if !isService && c.Host == "" {
 		if err := loadConfigFromProvider(); err != nil {
@@ -259,11 +259,11 @@ func (c *Config) Initialize(configDir string, isService bool) error {
 		}
 		return c.loadTemplates(configDir)
 	}
-	if err := c.loadTemplates(configDir); err != nil {
-		return err
-	}
 	if c.Host == "" {
 		return loadConfigFromProvider()
+	}
+	if err := c.loadTemplates(configDir); err != nil {
+		return err
 	}
 	if err := c.validate(); err != nil {
 		return err


### PR DESCRIPTION
Hi! 

This small fix aligns SMTP with the current `httpd` behaviour: at the moment, even if `smtp.host` is `''`, it still tries to load the templates before actually disabling SMTP capabilities.

This change allows to `serve` without the templates/bundle if both `httpd` and `smtp` are explicitly disabled.