### PR TITLE
Support AWS STS temporary credentials.

### DIFF
--- a/internal/vfs/s3fs.go
+++ b/internal/vfs/s3fs.go
@@ -113,7 +113,7 @@ func NewS3Fs(connectionID, localTempDir, mountPath string, s3Config S3FsConfig) 
 			return fs, err
 		}
 		awsConfig.Credentials = aws.NewCredentialsCache(
-			credentials.NewStaticCredentialsProvider(fs.config.AccessKey, fs.config.AccessSecret.GetPayload(), ""))
+			credentials.NewStaticCredentialsProvider(fs.config.AccessKey, fs.config.AccessSecret.GetPayload(), fs.config.SessionToken))
 	}
 
 	fs.setConfigDefaults()

--- a/internal/vfs/vfs.go
+++ b/internal/vfs/vfs.go
@@ -266,6 +266,7 @@ func (q *QuotaCheckResult) GetRemainingFiles() int {
 type S3FsConfig struct {
 	sdk.BaseS3FsConfig
 	AccessSecret *kms.Secret `json:"access_secret,omitempty"`
+	SessionToken string      `json:"session_token,omitempty"`
 }
 
 // HideConfidentialData hides confidential data

--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -5544,6 +5544,9 @@ components:
           minLength: 1
         access_key:
           type: string
+        session_token:
+          type: string
+          description: 'Optional Session token that is a part of temporary security credentials provisioned by AWS STS. Leave empty to use standard IAM credentials. For more information about temporary credentials, see here: https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_temp.html'
         access_secret:
           $ref: '#/components/schemas/Secret'
         role_arn:


### PR DESCRIPTION
**Motivation: Introducing Temporary AWS Credentials for Enhanced S3 Authorization**

This Pull Request introduces the capability to use AWS temporary credentials for seamless access to S3 buckets. Temporary credentials, as outlined in the [AWS documentation](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_temp.html), offer a secure and dynamic approach to IAM (Identity and Access Management) within the AWS ecosystem.

**Use Case: Pre-login Webhook Integration**

The necessity for this feature arises in scenarios involving a pre-login webhook:

- A user attempts to log in via SFTP.
- SftpGo triggers a pre-login webhook to retrieve user configurations.
- An external service responds with user-specific configurations, including virtual folders and AWS S3 settings.
- SftpGo must now act on behalf of the AWS IAM credentials provided in the S3 configuration from the previous step.

At the moment SFTPGo supports AWS IAM User credentials (accessKey, accessSecret) or the AssumeRole flow. However, we would like to extend it so SFTPGo can use AWS temporary credentials as well. This gives more flexibility and control over provided permissions.

**Proposed Solution: Introducing session_token Property**

This Pull Request introduces `session_token` property into the S3FsConfig. This addition allows SftpGo to utilize temporary AWS IAM credentials seamlessly.

**User Interface Considerations**

Given the ephemeral nature of these credentials, the PR omits a UI update for creating them. Manually configuring temporary credentials through the UI is deemed impractical due to their short-lived nature.