### PR TITLE
fix: go test is failing - download go1.22 for darwin/arm64: toolchain…

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/drakkan/sftpgo/v2
 
-go 1.22
+go 1.22.0
 
 require (
 	cloud.google.com/go/storage v1.39.1


### PR DESCRIPTION
## Trace Output
go: downloading go1.22 (darwin/arm64)
go: download go1.22 for darwin/arm64: toolchain not available

## Expected
According to this: https://github.com/golang/go/issues/65568#issuecomment-1954876836, go version should be more specific, i.e. 1.22.0.

## Reproduce
```
go test .
```

You should get the following error

```
go: downloading go1.22 (darwin/arm64)
go: download go1.22 for darwin/arm64: toolchain not available
```
