### PR TITLE
Support variable JWT session durations

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -399,6 +399,7 @@ func Init() {
 			SigningPassphrase:     "",
 			SigningPassphraseFile: "",
 			TokenValidation:       0,
+			TokenDuration:         20,
 			MaxUploadFileSize:     0,
 			Cors: httpd.CorsConfig{
 				Enabled:              false,
@@ -2131,6 +2132,7 @@ func setViperDefaults() {
 	viper.SetDefault("httpd.signing_passphrase", globalConf.HTTPDConfig.SigningPassphrase)
 	viper.SetDefault("httpd.signing_passphrase_file", globalConf.HTTPDConfig.SigningPassphraseFile)
 	viper.SetDefault("httpd.token_validation", globalConf.HTTPDConfig.TokenValidation)
+	viper.SetDefault("httpd.token_duration", globalConf.HTTPDConfig.TokenDuration)
 	viper.SetDefault("httpd.max_upload_file_size", globalConf.HTTPDConfig.MaxUploadFileSize)
 	viper.SetDefault("httpd.cors.enabled", globalConf.HTTPDConfig.Cors.Enabled)
 	viper.SetDefault("httpd.cors.allowed_origins", globalConf.HTTPDConfig.Cors.AllowedOrigins)

--- a/internal/httpd/httpd.go
+++ b/internal/httpd/httpd.go
@@ -763,6 +763,8 @@ type Conf struct {
 	// By default all the available security checks are enabled. Set to 1 to disable the requirement
 	// that a token must be used by the same IP for which it was issued.
 	TokenValidation int `json:"token_validation" mapstructure:"token_validation"`
+	// TokenDuration sets the duration of JWT tokens in minutes, by default this is set to 20 minutes.
+	TokenDuration int `json:"token_duration" mapstructure:"token_duration"`
 	// MaxUploadFileSize Defines the maximum request body size, in bytes, for Web Client/API HTTP upload requests.
 	// 0 means no limit
 	MaxUploadFileSize int64 `json:"max_upload_file_size" mapstructure:"max_upload_file_size"`
@@ -1003,6 +1005,7 @@ func (c *Conf) Initialize(configDir string, isShared int) error {
 	maxUploadFileSize = c.MaxUploadFileSize
 	installationCode = c.Setup.InstallationCode
 	installationCodeHint = c.Setup.InstallationCodeHint
+	tokenDuration = time.Duration(c.TokenDuration) * time.Minute
 	startCleanupTicker(tokenDuration / 2)
 	c.setTokenValidationMode()
 	return <-exitChannel

--- a/sftpgo.json
+++ b/sftpgo.json
@@ -352,6 +352,7 @@
     "signing_passphrase": "",
     "signing_passphrase_file": "",
     "token_validation": 0,
+    "token_duration": 20,
     "max_upload_file_size": 0,
     "cors": {
       "enabled": false,


### PR DESCRIPTION
This change introduces a runtime configuration variable `httpd.token_duration` which allows for variable JWT token durations specified as a number of minutes. If unspecified the token duration defaults to the historically hardcoded default value of 20 minutes.