### PR TITLE
adjust Sign in with OpenID to Sign in with and let OpenID be replaceable

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -121,6 +121,7 @@ var (
 		RenderOpenAPI:        true,
 		Languages:            []string{"en"},
 		OIDC: httpd.OIDC{
+			DisplayName:                "OpenID",
 			ClientID:                   "",
 			ClientSecret:               "",
 			ClientSecretFile:           "",
@@ -1623,6 +1624,12 @@ func getHTTPDOIDCFromEnv(idx int) (httpd.OIDC, bool) {
 	configURL, ok := os.LookupEnv(fmt.Sprintf("SFTPGO_HTTPD__BINDINGS__%v__OIDC__CONFIG_URL", idx))
 	if ok {
 		result.ConfigURL = configURL
+		isSet = true
+	}
+
+	displayName, ok := os.LookupEnv(fmt.Sprintf("SFTPGO_HTTPD__BINDINGS__%v__OIDC__DISPLAY_NAME", idx))
+	if ok {
+		result.DisplayName = displayName
 		isSet = true
 	}
 

--- a/internal/httpd/oidc.go
+++ b/internal/httpd/oidc.go
@@ -76,6 +76,8 @@ type OIDC struct {
 	// "web_root" if configured
 	RedirectBaseURL string `json:"redirect_base_url" mapstructure:"redirect_base_url"`
 	// ID token claims field to map to the SFTPGo username
+	DisplayName string `json:"display_name" mapstructure:"display_name"`
+	// sets the label to display for the OIDC provider
 	UsernameField string `json:"username_field" mapstructure:"username_field"`
 	// Optional ID token claims field to map to a SFTPGo role.
 	// If the defined ID token claims field is set to "admin" the authenticated user

--- a/internal/httpd/server.go
+++ b/internal/httpd/server.go
@@ -192,6 +192,7 @@ func (s *httpdServer) renderClientLoginPage(w http.ResponseWriter, r *http.Reque
 		data.ForgotPwdURL = webClientForgotPwdPath
 	}
 	if s.binding.OIDC.isEnabled() && !s.binding.isWebClientOIDCLoginDisabled() {
+		data.OpenIDDisplayName = s.binding.OIDC.DisplayName
 		data.OpenIDLoginURL = webClientOIDCLoginPath
 	}
 	renderClientTemplate(w, templateCommonLogin, data)
@@ -608,6 +609,7 @@ func (s *httpdServer) renderAdminLoginPage(w http.ResponseWriter, r *http.Reques
 		data.ForgotPwdURL = webAdminForgotPwdPath
 	}
 	if s.binding.OIDC.hasRoles() && !s.binding.isWebAdminOIDCLoginDisabled() {
+		data.OpenIDDisplayName = s.binding.OIDC.DisplayName
 		data.OpenIDLoginURL = webAdminOIDCLoginPath
 	}
 	renderAdminTemplate(w, templateCommonLogin, data)

--- a/internal/httpd/web.go
+++ b/internal/httpd/web.go
@@ -58,18 +58,19 @@ type commonBasePage struct {
 
 type loginPage struct {
 	commonBasePage
-	CurrentURL     string
-	Error          *util.I18nError
-	CSRFToken      string
-	AltLoginURL    string
-	AltLoginName   string
-	ForgotPwdURL   string
-	OpenIDLoginURL string
-	Title          string
-	Branding       UIBranding
-	Languages      []string
-	FormDisabled   bool
-	CheckRedirect  bool
+	CurrentURL        string
+	Error             *util.I18nError
+	CSRFToken         string
+	AltLoginURL       string
+	AltLoginName      string
+	ForgotPwdURL      string
+	OpenIDLoginURL    string
+	OpenIDDisplayName string
+	Title             string
+	Branding          UIBranding
+	Languages         []string
+	FormDisabled      bool
+	CheckRedirect     bool
 }
 
 type twoFactorPage struct {

--- a/sftpgo.json
+++ b/sftpgo.json
@@ -290,6 +290,7 @@
           "en"
         ],
         "oidc": {
+          "display_name": "OpenID",
           "client_id": "",
           "client_secret": "",
           "client_secret_file": "",

--- a/static/locales/en/translation.json
+++ b/static/locales/en/translation.json
@@ -81,7 +81,7 @@
         "forgot_password_msg": "Enter your account username below, you will receive a password reset code by email.",
         "send_reset_code": "Send Reset Code",
         "signin": "Sign in",
-        "signin_openid": "Sign in with OpenID",
+        "signin_with": "Sign in with",
         "signout": "Sign out",
         "auth_code": "Authentication code",
         "two_factor_help": "Open the two-factor authentication app on your device to view your authentication code and verify your identity.",

--- a/static/locales/it/translation.json
+++ b/static/locales/it/translation.json
@@ -81,7 +81,7 @@
         "forgot_password_msg": "Inserisci il nome utente del tuo account qui sotto, riceverai un codice di reimpostazione della password via e-mail.",
         "send_reset_code": "Invia codice di ripristino",
         "signin": "Accedi",
-        "signin_openid": "Accedi con OpenID",
+        "signin_with": "Accedi con",
         "signout": "Esci",
         "auth_code": "Codice di autenticazione",
         "two_factor_help": "Apri l'app di autenticazione a due fattori sul tuo dispositivo per visualizzare il tuo codice di autenticazione e verificare la tua identità.",

--- a/templates/common/login.html
+++ b/templates/common/login.html
@@ -72,7 +72,13 @@ explicit grant from the SFTPGo Team (support@sftpgo.com).
 								{{- if .OpenIDLoginURL}}
 								<a href="{{.OpenIDLoginURL}}" class="btn btn-flex btn-outline flex-center {{if .FormDisabled}}btn-primary{{else}}btn-active-color-primary bg-state-light{{end}} btn-lg w-100 my-5">
 									<img alt="Logo" src="{{.StaticURL}}/img/openid-logo.png" class="h-20px me-3" />
-									<span data-i18n="login.signin_openid">Sign in with OpenID</span>
+									<span data-i18n="login.signin_with">Sign in with</span>
+									&nbsp;
+									{{- if .OpenIDDisplayName}} 
+										{{ .OpenIDDisplayName }} 
+									{{- else}} 
+										OpenID 
+									{{- end}}
 								</a>
 								{{- end}}
 							</div>


### PR DESCRIPTION
Adjusts the UI to let "Login with OpenID" instead be "Login with Google", "Login with Office 365", "Login with Okta", "Login with Corporate Credentials", etc.


- [X] Have you signed the [Contributor License Agreement](https://sftpgo.com/cla.html)?

---
