### PR TITLE
metric: treat io.EOF as successful upload, not an error

### DIFF
--- a/internal/metric/metric.go
+++ b/internal/metric/metric.go
@@ -18,6 +18,9 @@
 package metric
 
 import (
+	"errors"
+	"io"
+
 	"github.com/go-chi/chi/v5"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
@@ -648,7 +651,7 @@ func AddMetricsEndpoint(metricsPath string, handler chi.Router) {
 func TransferCompleted(bytesSent, bytesReceived int64, transferKind int, err error, isSFTPFs bool) {
 	if transferKind == 0 {
 		// upload
-		if err == nil {
+		if err == nil || errors.Is(err, io.EOF) {
 			totalUploads.Inc()
 		} else {
 			totalUploadErrors.Inc()


### PR DESCRIPTION
This pull request introduces enhancements to the `internal/metric/metric.go` file, focusing on error handling and dependency updates. The changes improve the robustness of metrics tracking by accounting for additional error scenarios and updating imports.

### Error handling improvements:
* Modified the `TransferCompleted` function to increment `totalUploads` even when the error is `io.EOF`, ensuring proper metrics tracking for completed transfers despite this specific error condition.

### Dependency updates:
* Added imports for `errors` and `io` packages to support the new error handling logic in the `TransferCompleted` function.Uploads that end with io.EOF are now considered successful and no longer increment the upload error metric. This aligns metric reporting with Go convention, where io.EOF indicates normal completion rather than an error.

# Checklist for Pull Requests

- [x] Have you signed the [Contributor License Agreement](https://sftpgo.com/cla.html)?

---
