### PR TITLE
Add subdirectory option to virtual folders

### DIFF
--- a/examples/ldapauthserver/httpd/models.go
+++ b/examples/ldapauthserver/httpd/models.go
@@ -58,8 +58,9 @@ type SFTPGoFilesystem struct {
 }
 
 type virtualFolder struct {
-	VirtualPath string `json:"virtual_path"`
-	MappedPath  string `json:"mapped_path"`
+	VirtualPath        string `json:"virtual_path"`
+	MappedSubdirectory string `json:"mapped_subdirectory,omitempty"`
+	MappedPath         string `json:"mapped_path"`
 }
 
 // SFTPGoUser defines an SFTPGo user

--- a/examples/php-activedirectory-http-server/README.md
+++ b/examples/php-activedirectory-http-server/README.md
@@ -49,6 +49,18 @@ $virtual_folders['example'] = [
       "quota_files" => -1
     ]
 ];
+
+// Alternative example using mapped_subdirectory for multi-tenant shared storage:
+$virtual_folders['shared_example'] = [
+    [
+      "name" => "shared-documents",
+      "mapped_path" => 'F:\files\shared\documents',
+      "virtual_path" => "/documents",
+      "mapped_subdirectory" => "#USERNAME#",
+      "quota_size" => -1,
+      "quota_files" => -1
+    ]
+];
 ```
 
 ## Example Connection "Output Object" Allowing For No Files in the User's Home Directory ("Root Directory") but Allowing for Files in the Public/Private Virtual Folders

--- a/internal/dataprovider/bolt.go
+++ b/internal/dataprovider/bolt.go
@@ -39,7 +39,7 @@ import (
 )
 
 const (
-	boltDatabaseVersion = 34
+	boltDatabaseVersion = 35
 )
 
 var (
@@ -3170,11 +3170,10 @@ func (p *BoltProvider) migrateDatabase() error {
 		providerLog(logger.LevelError, "%v", err)
 		logger.ErrorToConsole("%v", err)
 		return err
-	case version == 33:
-		logger.InfoToConsole("updating database schema version: %d -> 34", version)
-		providerLog(logger.LevelInfo, "updating database schema version: %d -> 34", version)
-		return updateBoltDatabaseVersion(p.dbHandle, 34)
-
+	case version == 33, version == 34:
+		logger.InfoToConsole("updating database schema version: %d -> 35", version)
+		providerLog(logger.LevelInfo, "updating database schema version: %d -> 35", version)
+		return updateBoltDatabaseVersion(p.dbHandle, 35)
 	default:
 		if version > boltDatabaseVersion {
 			providerLog(logger.LevelError, "database schema version %d is newer than the supported one: %d", version,
@@ -3200,7 +3199,10 @@ func (p *BoltProvider) revertDatabase(targetVersion int) error {
 		logger.InfoToConsole("downgrading database schema version: %d -> 33", dbVersion.Version)
 		providerLog(logger.LevelInfo, "downgrading database schema version: %d -> 33", dbVersion.Version)
 		return updateBoltDatabaseVersion(p.dbHandle, 33)
-
+	case 35:
+		logger.InfoToConsole("downgrading database schema version: %d -> 34", dbVersion.Version)
+		providerLog(logger.LevelInfo, "downgrading database schema version: %d -> 34", dbVersion.Version)
+		return updateBoltDatabaseVersion(p.dbHandle, 34)
 	default:
 		return fmt.Errorf("database schema version not handled: %v", dbVersion.Version)
 	}

--- a/internal/dataprovider/dataprovider.go
+++ b/internal/dataprovider/dataprovider.go
@@ -190,7 +190,10 @@ var (
 	// ErrShareUsageExceeded is returned when reserving share usage tokens would exceed the share max_tokens limit
 	ErrShareUsageExceeded = util.NewI18nError(
 		util.NewRecordNotFoundError("max share usage exceeded"), util.I18nErrorShareUsage)
-	errInvalidInput         = util.NewValidationError("Invalid input. Slashes (/ ), colons (:), control characters, and reserved system names are not allowed")
+	errInvalidInput              = util.NewValidationError("Invalid input. Slashes (/ ), colons (:), control characters, and reserved system names are not allowed")
+	errInvalidMappedSubdirectory = util.NewI18nError(
+		util.NewValidationError("mapped subdirectory must be a relative path that does not escape the mapped root"),
+		util.I18nErrorPathInvalid)
 	tz                      = ""
 	isAdminCreated          atomic.Bool
 	validTLSUsernames       = []string{string(sdk.TLSUsernameNone), string(sdk.TLSUsernameCN)}
@@ -2772,7 +2775,7 @@ func validateAssociatedVirtualFolders(vfolders []vfs.VirtualFolder) ([]vfs.Virtu
 		return []vfs.VirtualFolder{}, nil
 	}
 	var virtualFolders []vfs.VirtualFolder
-	folderNames := make(map[string]bool)
+	folderKeys := make(map[[2]string]bool)
 
 	for _, v := range vfolders {
 		v.Name = config.convertName(v.Name)
@@ -2789,9 +2792,18 @@ func validateAssociatedVirtualFolders(vfolders []vfs.VirtualFolder) ([]vfs.Virtu
 		if v.Name == "" {
 			return nil, util.NewI18nError(util.NewValidationError("folder name is mandatory"), util.I18nErrorFolderNameRequired)
 		}
-		if folderNames[v.Name] {
+		subdir, err := normalizeMappedSubdirectory(v.MappedSubdirectory)
+		if err != nil {
+			return nil, err
+		}
+		v.MappedSubdirectory = subdir
+		if err := validateMappedSubdirectoryQuota(v); err != nil {
+			return nil, err
+		}
+		folderKey := [2]string{v.Name, subdir}
+		if folderKeys[folderKey] {
 			return nil, util.NewI18nError(
-				util.NewValidationError(fmt.Sprintf("the folder %q is duplicated", v.Name)),
+				util.NewValidationError(duplicatedFolderMessage(v.Name, subdir)),
 				util.I18nErrorDuplicatedFolders,
 			)
 		}
@@ -2808,13 +2820,56 @@ func validateAssociatedVirtualFolders(vfolders []vfs.VirtualFolder) ([]vfs.Virtu
 			BaseVirtualFolder: vfs.BaseVirtualFolder{
 				Name: v.Name,
 			},
-			VirtualPath: cleanedVPath,
-			QuotaSize:   v.QuotaSize,
-			QuotaFiles:  v.QuotaFiles,
+			VirtualPath:        cleanedVPath,
+			MappedSubdirectory: subdir,
+			QuotaSize:          v.QuotaSize,
+			QuotaFiles:         v.QuotaFiles,
 		})
-		folderNames[v.Name] = true
+		folderKeys[folderKey] = true
 	}
 	return virtualFolders, nil
+}
+
+func duplicatedFolderMessage(name, subdir string) string {
+	if subdir != "" {
+		return fmt.Sprintf("the folder %q with subdirectory %q is duplicated", name, subdir)
+	}
+	return fmt.Sprintf("the folder %q is duplicated", name)
+}
+
+func normalizeMappedSubdirectory(value string) (string, error) {
+	if value == "" {
+		return "", nil
+	}
+	value = strings.ReplaceAll(value, "\\", "/") // collapse "\" like CleanPath, so it can't evade the checks below
+	if path.IsAbs(value) {
+		return "", errInvalidMappedSubdirectory
+	}
+	clean := path.Clean(value)
+	if clean == "." {
+		return "", nil
+	}
+	if clean == ".." || strings.HasPrefix(clean, "../") {
+		return "", errInvalidMappedSubdirectory
+	}
+	// capped uniformly so a config stays valid across providers: the column is
+	// part of a unique index and MySQL stores it as varchar(255)
+	if len(clean) > 255 {
+		return "", util.NewI18nError(
+			util.NewValidationError("mapped subdirectory is too long, 255 is the maximum length allowed"),
+			util.I18nErrorPathInvalid)
+	}
+	return clean, nil
+}
+
+func validateMappedSubdirectoryQuota(v vfs.VirtualFolder) error {
+	if v.MappedSubdirectory != "" && (v.QuotaSize > 0 || v.QuotaFiles > 0) {
+		return util.NewI18nError(
+			util.NewValidationError("a positive quota applies to the whole folder, not the mapped subdirectory: use -1 to include it in the user quota, or 0 for no limit"),
+			util.I18nErrorFolderQuotaInvalid,
+		)
+	}
+	return nil
 }
 
 func validateUserTOTPConfig(c *UserTOTPConfig, username string) error {

--- a/internal/dataprovider/mysql.go
+++ b/internal/dataprovider/mysql.go
@@ -207,6 +207,18 @@ const (
 		"CREATE INDEX `{{prefix}}shares_groups_mapping_share_id_idx` ON `{{shares_groups_mapping}}` (`share_id`); " +
 		"CREATE INDEX `{{prefix}}shares_groups_mapping_group_id_idx` ON `{{shares_groups_mapping}}` (`group_id`);"
 	mysqlV34DownSQL = "DROP TABLE IF EXISTS `{{shares_groups_mapping}}`;"
+	mysqlV35SQL     = "ALTER TABLE `{{users_folders_mapping}}` ADD COLUMN `subdirectory` varchar(255) NOT NULL DEFAULT '';" +
+		"ALTER TABLE `{{groups_folders_mapping}}` ADD COLUMN `subdirectory` varchar(255) NOT NULL DEFAULT '';" +
+		"ALTER TABLE `{{users_folders_mapping}}` DROP CONSTRAINT `{{prefix}}unique_user_folder_mapping`;" +
+		"ALTER TABLE `{{users_folders_mapping}}` ADD CONSTRAINT `{{prefix}}unique_user_folder_mapping` UNIQUE (`user_id`, `folder_id`, `subdirectory`);" +
+		"ALTER TABLE `{{groups_folders_mapping}}` DROP CONSTRAINT `{{prefix}}unique_group_folder_mapping`;" +
+		"ALTER TABLE `{{groups_folders_mapping}}` ADD CONSTRAINT `{{prefix}}unique_group_folder_mapping` UNIQUE (`group_id`, `folder_id`, `subdirectory`);"
+	mysqlV35DownSQL = "ALTER TABLE `{{users_folders_mapping}}` DROP CONSTRAINT `{{prefix}}unique_user_folder_mapping`;" +
+		"ALTER TABLE `{{groups_folders_mapping}}` DROP CONSTRAINT `{{prefix}}unique_group_folder_mapping`;" +
+		"ALTER TABLE `{{users_folders_mapping}}` ADD CONSTRAINT `{{prefix}}unique_user_folder_mapping` UNIQUE (`user_id`, `folder_id`);" +
+		"ALTER TABLE `{{groups_folders_mapping}}` ADD CONSTRAINT `{{prefix}}unique_group_folder_mapping` UNIQUE (`group_id`, `folder_id`);" +
+		"ALTER TABLE `{{users_folders_mapping}}` DROP COLUMN `subdirectory`;" +
+		"ALTER TABLE `{{groups_folders_mapping}}` DROP COLUMN `subdirectory`;"
 )
 
 // MySQLProvider defines the auth provider for MySQL/MariaDB database
@@ -817,6 +829,8 @@ func (p *MySQLProvider) migrateDatabase() error {
 		return err
 	case version == 33:
 		return updateMySQLDatabaseFromV33(p.dbHandle)
+	case version == 34:
+		return updateMySQLDatabaseFromV34(p.dbHandle)
 	default:
 		if version > sqlDatabaseVersion {
 			providerLog(logger.LevelError, "database schema version %d is newer than the supported one: %d", version,
@@ -841,6 +855,8 @@ func (p *MySQLProvider) revertDatabase(targetVersion int) error {
 	switch dbVersion.Version {
 	case 34:
 		return downgradeMySQLDatabaseFromV34(p.dbHandle)
+	case 35:
+		return downgradeMySQLDatabaseFromV35(p.dbHandle)
 	default:
 		return fmt.Errorf("database schema version not handled: %d", dbVersion.Version)
 	}
@@ -880,11 +896,25 @@ func (p *MySQLProvider) normalizeError(err error, fieldType int) error {
 }
 
 func updateMySQLDatabaseFromV33(dbHandle *sql.DB) error {
-	return updateMySQLDatabaseFrom33To34(dbHandle)
+	if err := updateMySQLDatabaseFrom33To34(dbHandle); err != nil {
+		return err
+	}
+	return updateMySQLDatabaseFromV34(dbHandle)
+}
+
+func updateMySQLDatabaseFromV34(dbHandle *sql.DB) error {
+	return updateMySQLDatabaseFrom34To35(dbHandle)
 }
 
 func downgradeMySQLDatabaseFromV34(dbHandle *sql.DB) error {
 	return downgradeMySQLDatabaseFrom34To33(dbHandle)
+}
+
+func downgradeMySQLDatabaseFromV35(dbHandle *sql.DB) error {
+	if err := downgradeMySQLDatabaseFrom35To34(dbHandle); err != nil {
+		return err
+	}
+	return downgradeMySQLDatabaseFromV34(dbHandle)
 }
 
 func updateMySQLDatabaseFrom33To34(dbHandle *sql.DB) error {
@@ -904,4 +934,24 @@ func downgradeMySQLDatabaseFrom34To33(dbHandle *sql.DB) error {
 
 	sql := strings.ReplaceAll(mysqlV34DownSQL, "{{shares_groups_mapping}}", sqlTableSharesGroupsMapping)
 	return sqlCommonExecSQLAndUpdateDBVersion(dbHandle, strings.Split(sql, ";"), 33, false)
+}
+
+func updateMySQLDatabaseFrom34To35(dbHandle *sql.DB) error {
+	logger.InfoToConsole("updating database schema version: 34 -> 35")
+	providerLog(logger.LevelInfo, "updating database schema version: 34 -> 35")
+
+	sql := strings.ReplaceAll(mysqlV35SQL, "{{prefix}}", config.SQLTablesPrefix)
+	sql = strings.ReplaceAll(sql, "{{users_folders_mapping}}", sqlTableUsersFoldersMapping)
+	sql = strings.ReplaceAll(sql, "{{groups_folders_mapping}}", sqlTableGroupsFoldersMapping)
+	return sqlCommonExecSQLAndUpdateDBVersion(dbHandle, strings.Split(sql, ";"), 35, true)
+}
+
+func downgradeMySQLDatabaseFrom35To34(dbHandle *sql.DB) error {
+	logger.InfoToConsole("downgrading database schema version: 35 -> 34")
+	providerLog(logger.LevelInfo, "downgrading database schema version: 35 -> 34")
+
+	sql := strings.ReplaceAll(mysqlV35DownSQL, "{{prefix}}", config.SQLTablesPrefix)
+	sql = strings.ReplaceAll(sql, "{{users_folders_mapping}}", sqlTableUsersFoldersMapping)
+	sql = strings.ReplaceAll(sql, "{{groups_folders_mapping}}", sqlTableGroupsFoldersMapping)
+	return sqlCommonExecSQLAndUpdateDBVersion(dbHandle, strings.Split(sql, ";"), 34, false)
 }

--- a/internal/dataprovider/pgsql.go
+++ b/internal/dataprovider/pgsql.go
@@ -227,6 +227,18 @@ CREATE INDEX "{{prefix}}shares_groups_mapping_share_id_idx" ON "{{shares_groups_
 CREATE INDEX "{{prefix}}shares_groups_mapping_group_id_idx" ON "{{shares_groups_mapping}}" ("group_id");
 `
 	pgsqlV34DownSQL = `DROP TABLE IF EXISTS "{{shares_groups_mapping}}";`
+	pgsqlV35SQL     = `ALTER TABLE "{{users_folders_mapping}}" ADD COLUMN "subdirectory" text NOT NULL DEFAULT '';
+ALTER TABLE "{{groups_folders_mapping}}" ADD COLUMN "subdirectory" text NOT NULL DEFAULT '';
+ALTER TABLE "{{users_folders_mapping}}" DROP CONSTRAINT "{{prefix}}unique_user_folder_mapping";
+ALTER TABLE "{{users_folders_mapping}}" ADD CONSTRAINT "{{prefix}}unique_user_folder_mapping" UNIQUE ("user_id", "folder_id", "subdirectory");
+ALTER TABLE "{{groups_folders_mapping}}" DROP CONSTRAINT "{{prefix}}unique_group_folder_mapping";
+ALTER TABLE "{{groups_folders_mapping}}" ADD CONSTRAINT "{{prefix}}unique_group_folder_mapping" UNIQUE ("group_id", "folder_id", "subdirectory");`
+	pgsqlV35DownSQL = `ALTER TABLE "{{users_folders_mapping}}" DROP CONSTRAINT "{{prefix}}unique_user_folder_mapping";
+ALTER TABLE "{{groups_folders_mapping}}" DROP CONSTRAINT "{{prefix}}unique_group_folder_mapping";
+ALTER TABLE "{{users_folders_mapping}}" ADD CONSTRAINT "{{prefix}}unique_user_folder_mapping" UNIQUE ("user_id", "folder_id");
+ALTER TABLE "{{groups_folders_mapping}}" ADD CONSTRAINT "{{prefix}}unique_group_folder_mapping" UNIQUE ("group_id", "folder_id");
+ALTER TABLE "{{users_folders_mapping}}" DROP COLUMN "subdirectory" CASCADE;
+ALTER TABLE "{{groups_folders_mapping}}" DROP COLUMN "subdirectory" CASCADE;`
 )
 
 var (
@@ -845,6 +857,8 @@ func (p *PGSQLProvider) migrateDatabase() error {
 		return err
 	case version == 33:
 		return updatePGSQLDatabaseFromV33(p.dbHandle)
+	case version == 34:
+		return updatePGSQLDatabaseFromV34(p.dbHandle)
 	default:
 		if version > sqlDatabaseVersion {
 			providerLog(logger.LevelError, "database schema version %d is newer than the supported one: %d", version,
@@ -869,6 +883,8 @@ func (p *PGSQLProvider) revertDatabase(targetVersion int) error {
 	switch dbVersion.Version {
 	case 34:
 		return downgradePGSQLDatabaseFromV34(p.dbHandle)
+	case 35:
+		return downgradePGSQLDatabaseFromV35(p.dbHandle)
 	default:
 		return fmt.Errorf("database schema version not handled: %d", dbVersion.Version)
 	}
@@ -908,11 +924,25 @@ func (p *PGSQLProvider) normalizeError(err error, fieldType int) error {
 }
 
 func updatePGSQLDatabaseFromV33(dbHandle *sql.DB) error {
-	return updatePGSQLDatabaseFrom33To34(dbHandle)
+	if err := updatePGSQLDatabaseFrom33To34(dbHandle); err != nil {
+		return err
+	}
+	return updatePGSQLDatabaseFromV34(dbHandle)
+}
+
+func updatePGSQLDatabaseFromV34(dbHandle *sql.DB) error {
+	return updatePGSQLDatabaseFrom34To35(dbHandle)
 }
 
 func downgradePGSQLDatabaseFromV34(dbHandle *sql.DB) error {
 	return downgradePGSQLDatabaseFrom34To33(dbHandle)
+}
+
+func downgradePGSQLDatabaseFromV35(dbHandle *sql.DB) error {
+	if err := downgradePGSQLDatabaseFrom35To34(dbHandle); err != nil {
+		return err
+	}
+	return downgradePGSQLDatabaseFromV34(dbHandle)
 }
 
 func updatePGSQLDatabaseFrom33To34(dbHandle *sql.DB) error {
@@ -932,4 +962,24 @@ func downgradePGSQLDatabaseFrom34To33(dbHandle *sql.DB) error {
 
 	sql := strings.ReplaceAll(pgsqlV34DownSQL, "{{shares_groups_mapping}}", sqlTableSharesGroupsMapping)
 	return sqlCommonExecSQLAndUpdateDBVersion(dbHandle, []string{sql}, 33, false)
+}
+
+func updatePGSQLDatabaseFrom34To35(dbHandle *sql.DB) error {
+	logger.InfoToConsole("updating database schema version: 34 -> 35")
+	providerLog(logger.LevelInfo, "updating database schema version: 34 -> 35")
+
+	sql := strings.ReplaceAll(pgsqlV35SQL, "{{prefix}}", config.SQLTablesPrefix)
+	sql = strings.ReplaceAll(sql, "{{users_folders_mapping}}", sqlTableUsersFoldersMapping)
+	sql = strings.ReplaceAll(sql, "{{groups_folders_mapping}}", sqlTableGroupsFoldersMapping)
+	return sqlCommonExecSQLAndUpdateDBVersion(dbHandle, []string{sql}, 35, true)
+}
+
+func downgradePGSQLDatabaseFrom35To34(dbHandle *sql.DB) error {
+	logger.InfoToConsole("downgrading database schema version: 35 -> 34")
+	providerLog(logger.LevelInfo, "downgrading database schema version: 35 -> 34")
+
+	sql := strings.ReplaceAll(pgsqlV35DownSQL, "{{prefix}}", config.SQLTablesPrefix)
+	sql = strings.ReplaceAll(sql, "{{users_folders_mapping}}", sqlTableUsersFoldersMapping)
+	sql = strings.ReplaceAll(sql, "{{groups_folders_mapping}}", sqlTableGroupsFoldersMapping)
+	return sqlCommonExecSQLAndUpdateDBVersion(dbHandle, []string{sql}, 34, false)
 }

--- a/internal/dataprovider/sqlcommon.go
+++ b/internal/dataprovider/sqlcommon.go
@@ -36,7 +36,7 @@ import (
 )
 
 const (
-	sqlDatabaseVersion     = 34
+	sqlDatabaseVersion     = 35
 	defaultSQLQueryTimeout = 10 * time.Second
 	longSQLQueryTimeout    = 60 * time.Second
 )
@@ -2543,7 +2543,7 @@ func sqlCommonClearUserGroupMapping(ctx context.Context, user *User, dbHandle sq
 
 func sqlCommonAddUserFolderMapping(ctx context.Context, user *User, folder *vfs.VirtualFolder, sortOrder int, dbHandle sqlQuerier) error {
 	q := getAddUserFolderMappingQuery()
-	_, err := dbHandle.ExecContext(ctx, q, folder.VirtualPath, folder.QuotaSize, folder.QuotaFiles, folder.Name, user.Username, sortOrder)
+	_, err := dbHandle.ExecContext(ctx, q, folder.VirtualPath, folder.MappedSubdirectory, folder.QuotaSize, folder.QuotaFiles, folder.Name, user.Username, sortOrder)
 	return err
 }
 
@@ -2557,7 +2557,7 @@ func sqlCommonAddGroupFolderMapping(ctx context.Context, group *Group, folder *v
 	dbHandle sqlQuerier,
 ) error {
 	q := getAddGroupFolderMappingQuery()
-	_, err := dbHandle.ExecContext(ctx, q, folder.VirtualPath, folder.QuotaSize, folder.QuotaFiles, folder.Name, group.Name, sortOrder)
+	_, err := dbHandle.ExecContext(ctx, q, folder.VirtualPath, folder.MappedSubdirectory, folder.QuotaSize, folder.QuotaFiles, folder.Name, group.Name, sortOrder)
 	return err
 }
 
@@ -2765,7 +2765,7 @@ func getUsersWithVirtualFolders(ctx context.Context, users []User, dbHandle sqlQ
 		var mappedPath, description sql.NullString
 		var fsConfig []byte
 		err = rows.Scan(&folder.ID, &folder.Name, &mappedPath, &folder.UsedQuotaSize, &folder.UsedQuotaFiles,
-			&folder.LastQuotaUpdate, &folder.VirtualPath, &folder.QuotaSize, &folder.QuotaFiles, &userID, &fsConfig,
+			&folder.LastQuotaUpdate, &folder.VirtualPath, &folder.MappedSubdirectory, &folder.QuotaSize, &folder.QuotaFiles, &userID, &fsConfig,
 			&description)
 		if err != nil {
 			return users, err
@@ -2916,7 +2916,7 @@ func getGroupsWithVirtualFolders(ctx context.Context, groups []Group, dbHandle s
 		var mappedPath, description sql.NullString
 		var fsConfig []byte
 		err = rows.Scan(&folder.ID, &folder.Name, &mappedPath, &folder.UsedQuotaSize, &folder.UsedQuotaFiles,
-			&folder.LastQuotaUpdate, &folder.VirtualPath, &folder.QuotaSize, &folder.QuotaFiles, &groupID, &fsConfig,
+			&folder.LastQuotaUpdate, &folder.VirtualPath, &folder.MappedSubdirectory, &folder.QuotaSize, &folder.QuotaFiles, &groupID, &fsConfig,
 			&description)
 		if err != nil {
 			return groups, err

--- a/internal/dataprovider/sqlite.go
+++ b/internal/dataprovider/sqlite.go
@@ -198,6 +198,38 @@ CREATE INDEX "{{prefix}}shares_groups_mapping_group_id_idx" ON "{{shares_groups_
 CREATE INDEX "{{prefix}}shares_groups_mapping_share_id_idx" ON "{{shares_groups_mapping}}" ("share_id");
 `
 	sqliteV34DownSQL = `DROP TABLE IF EXISTS "{{shares_groups_mapping}}";`
+	sqliteV35SQL     = `ALTER TABLE "{{users_folders_mapping}}" ADD COLUMN "subdirectory" text NOT NULL DEFAULT '';
+ALTER TABLE "{{groups_folders_mapping}}" ADD COLUMN "subdirectory" text NOT NULL DEFAULT '';
+CREATE TABLE "{{users_folders_mapping}}_new" ("id" integer NOT NULL PRIMARY KEY, "virtual_path" text NOT NULL, "quota_size" bigint NOT NULL, "quota_files" integer NOT NULL, "user_id" integer NOT NULL REFERENCES "{{users}}" ("id") ON DELETE CASCADE DEFERRABLE INITIALLY DEFERRED, "folder_id" integer NOT NULL REFERENCES "{{folders}}" ("id") ON DELETE CASCADE DEFERRABLE INITIALLY DEFERRED, "subdirectory" text NOT NULL DEFAULT '', "sort_order" integer NOT NULL DEFAULT 0, CONSTRAINT "{{prefix}}unique_user_folder_mapping" UNIQUE ("user_id", "folder_id", "subdirectory"));
+INSERT INTO "{{users_folders_mapping}}_new" ("id", "virtual_path", "quota_size", "quota_files", "user_id", "folder_id", "subdirectory", "sort_order") SELECT "id", "virtual_path", "quota_size", "quota_files", "user_id", "folder_id", "subdirectory", "sort_order" FROM "{{users_folders_mapping}}";
+DROP TABLE "{{users_folders_mapping}}";
+ALTER TABLE "{{users_folders_mapping}}_new" RENAME TO "{{users_folders_mapping}}";
+CREATE TABLE "{{groups_folders_mapping}}_new" ("id" integer NOT NULL PRIMARY KEY, "virtual_path" text NOT NULL, "quota_size" bigint NOT NULL, "quota_files" integer NOT NULL, "group_id" integer NOT NULL REFERENCES "{{groups}}" ("id") ON DELETE CASCADE DEFERRABLE INITIALLY DEFERRED, "folder_id" integer NOT NULL REFERENCES "{{folders}}" ("id") ON DELETE CASCADE DEFERRABLE INITIALLY DEFERRED, "subdirectory" text NOT NULL DEFAULT '', "sort_order" integer NOT NULL DEFAULT 0, CONSTRAINT "{{prefix}}unique_group_folder_mapping" UNIQUE ("group_id", "folder_id", "subdirectory"));
+INSERT INTO "{{groups_folders_mapping}}_new" ("id", "virtual_path", "quota_size", "quota_files", "group_id", "folder_id", "subdirectory", "sort_order") SELECT "id", "virtual_path", "quota_size", "quota_files", "group_id", "folder_id", "subdirectory", "sort_order" FROM "{{groups_folders_mapping}}";
+DROP TABLE "{{groups_folders_mapping}}";
+ALTER TABLE "{{groups_folders_mapping}}_new" RENAME TO "{{groups_folders_mapping}}";
+CREATE INDEX "{{prefix}}users_folders_mapping_folder_id_idx" ON "{{users_folders_mapping}}" ("folder_id");
+CREATE INDEX "{{prefix}}users_folders_mapping_user_id_idx" ON "{{users_folders_mapping}}" ("user_id");
+CREATE INDEX "{{prefix}}users_folders_mapping_sort_order_idx" ON "{{users_folders_mapping}}" ("sort_order");
+CREATE INDEX "{{prefix}}groups_folders_mapping_folder_id_idx" ON "{{groups_folders_mapping}}" ("folder_id");
+CREATE INDEX "{{prefix}}groups_folders_mapping_group_id_idx" ON "{{groups_folders_mapping}}" ("group_id");
+CREATE INDEX "{{prefix}}groups_folders_mapping_sort_order_idx" ON "{{groups_folders_mapping}}" ("sort_order");
+`
+	sqliteV35DownSQL = `CREATE TABLE "{{users_folders_mapping}}_old" ("id" integer NOT NULL PRIMARY KEY, "virtual_path" text NOT NULL, "quota_size" bigint NOT NULL, "quota_files" integer NOT NULL, "user_id" integer NOT NULL REFERENCES "{{users}}" ("id") ON DELETE CASCADE DEFERRABLE INITIALLY DEFERRED, "folder_id" integer NOT NULL REFERENCES "{{folders}}" ("id") ON DELETE CASCADE DEFERRABLE INITIALLY DEFERRED, "sort_order" integer NOT NULL DEFAULT 0, CONSTRAINT "{{prefix}}unique_user_folder_mapping" UNIQUE ("user_id", "folder_id"));
+INSERT INTO "{{users_folders_mapping}}_old" ("id", "virtual_path", "quota_size", "quota_files", "user_id", "folder_id", "sort_order") SELECT "id", "virtual_path", "quota_size", "quota_files", "user_id", "folder_id", "sort_order" FROM "{{users_folders_mapping}}";
+DROP TABLE "{{users_folders_mapping}}";
+ALTER TABLE "{{users_folders_mapping}}_old" RENAME TO "{{users_folders_mapping}}";
+CREATE TABLE "{{groups_folders_mapping}}_old" ("id" integer NOT NULL PRIMARY KEY, "virtual_path" text NOT NULL, "quota_size" bigint NOT NULL, "quota_files" integer NOT NULL, "group_id" integer NOT NULL REFERENCES "{{groups}}" ("id") ON DELETE CASCADE DEFERRABLE INITIALLY DEFERRED, "folder_id" integer NOT NULL REFERENCES "{{folders}}" ("id") ON DELETE CASCADE DEFERRABLE INITIALLY DEFERRED, "sort_order" integer NOT NULL DEFAULT 0, CONSTRAINT "{{prefix}}unique_group_folder_mapping" UNIQUE ("group_id", "folder_id"));
+INSERT INTO "{{groups_folders_mapping}}_old" ("id", "virtual_path", "quota_size", "quota_files", "group_id", "folder_id", "sort_order") SELECT "id", "virtual_path", "quota_size", "quota_files", "group_id", "folder_id", "sort_order" FROM "{{groups_folders_mapping}}";
+DROP TABLE "{{groups_folders_mapping}}";
+ALTER TABLE "{{groups_folders_mapping}}_old" RENAME TO "{{groups_folders_mapping}}";
+CREATE INDEX "{{prefix}}users_folders_mapping_folder_id_idx" ON "{{users_folders_mapping}}" ("folder_id");
+CREATE INDEX "{{prefix}}users_folders_mapping_user_id_idx" ON "{{users_folders_mapping}}" ("user_id");
+CREATE INDEX "{{prefix}}users_folders_mapping_sort_order_idx" ON "{{users_folders_mapping}}" ("sort_order");
+CREATE INDEX "{{prefix}}groups_folders_mapping_folder_id_idx" ON "{{groups_folders_mapping}}" ("folder_id");
+CREATE INDEX "{{prefix}}groups_folders_mapping_group_id_idx" ON "{{groups_folders_mapping}}" ("group_id");
+CREATE INDEX "{{prefix}}groups_folders_mapping_sort_order_idx" ON "{{groups_folders_mapping}}" ("sort_order");
+`
 )
 
 // SQLiteProvider defines the auth provider for SQLite database
@@ -744,6 +776,8 @@ func (p *SQLiteProvider) migrateDatabase() error {
 		return err
 	case version == 33:
 		return updateSQLiteDatabaseFromV33(p.dbHandle)
+	case version == 34:
+		return updateSQLiteDatabaseFromV34(p.dbHandle)
 	default:
 		if version > sqlDatabaseVersion {
 			providerLog(logger.LevelError, "database schema version %d is newer than the supported one: %d", version,
@@ -768,6 +802,8 @@ func (p *SQLiteProvider) revertDatabase(targetVersion int) error {
 	switch dbVersion.Version {
 	case 34:
 		return downgradeSQLiteDatabaseFromV34(p.dbHandle)
+	case 35:
+		return downgradeSQLiteDatabaseFromV35(p.dbHandle)
 	default:
 		return fmt.Errorf("database schema version not handled: %d", dbVersion.Version)
 	}
@@ -814,11 +850,25 @@ func executePragmaOptimize(dbHandle *sql.DB) error {
 }
 
 func updateSQLiteDatabaseFromV33(dbHandle *sql.DB) error {
-	return updateSQLiteDatabaseFrom33To34(dbHandle)
+	if err := updateSQLiteDatabaseFrom33To34(dbHandle); err != nil {
+		return err
+	}
+	return updateSQLiteDatabaseFromV34(dbHandle)
+}
+
+func updateSQLiteDatabaseFromV34(dbHandle *sql.DB) error {
+	return updateSQLiteDatabaseFrom34To35(dbHandle)
 }
 
 func downgradeSQLiteDatabaseFromV34(dbHandle *sql.DB) error {
 	return downgradeSQLiteDatabaseFrom34To33(dbHandle)
+}
+
+func downgradeSQLiteDatabaseFromV35(dbHandle *sql.DB) error {
+	if err := downgradeSQLiteDatabaseFrom35To34(dbHandle); err != nil {
+		return err
+	}
+	return downgradeSQLiteDatabaseFromV34(dbHandle)
 }
 
 func updateSQLiteDatabaseFrom33To34(dbHandle *sql.DB) error {
@@ -838,6 +888,32 @@ func downgradeSQLiteDatabaseFrom34To33(dbHandle *sql.DB) error {
 
 	sql := strings.ReplaceAll(sqliteV34DownSQL, "{{shares_groups_mapping}}", sqlTableSharesGroupsMapping)
 	return sqlCommonExecSQLAndUpdateDBVersion(dbHandle, []string{sql}, 33, false)
+}
+
+func updateSQLiteDatabaseFrom34To35(dbHandle *sql.DB) error {
+	logger.InfoToConsole("updating SQLite database schema version: 34 -> 35")
+	providerLog(logger.LevelInfo, "updating SQLite database schema version: 34 -> 35")
+
+	sql := strings.ReplaceAll(sqliteV35SQL, "{{users_folders_mapping}}", sqlTableUsersFoldersMapping)
+	sql = strings.ReplaceAll(sql, "{{groups_folders_mapping}}", sqlTableGroupsFoldersMapping)
+	sql = strings.ReplaceAll(sql, "{{users}}", sqlTableUsers)
+	sql = strings.ReplaceAll(sql, "{{groups}}", sqlTableGroups)
+	sql = strings.ReplaceAll(sql, "{{folders}}", sqlTableFolders)
+	sql = strings.ReplaceAll(sql, "{{prefix}}", config.SQLTablesPrefix)
+	return sqlCommonExecSQLAndUpdateDBVersion(dbHandle, strings.Split(sql, ";"), 35, true)
+}
+
+func downgradeSQLiteDatabaseFrom35To34(dbHandle *sql.DB) error {
+	logger.InfoToConsole("downgrading database schema version: 35 -> 34")
+	providerLog(logger.LevelInfo, "downgrading database schema version: 35 -> 34")
+
+	sql := strings.ReplaceAll(sqliteV35DownSQL, "{{users_folders_mapping}}", sqlTableUsersFoldersMapping)
+	sql = strings.ReplaceAll(sql, "{{groups_folders_mapping}}", sqlTableGroupsFoldersMapping)
+	sql = strings.ReplaceAll(sql, "{{users}}", sqlTableUsers)
+	sql = strings.ReplaceAll(sql, "{{groups}}", sqlTableGroups)
+	sql = strings.ReplaceAll(sql, "{{folders}}", sqlTableFolders)
+	sql = strings.ReplaceAll(sql, "{{prefix}}", config.SQLTablesPrefix)
+	return sqlCommonExecSQLAndUpdateDBVersion(dbHandle, strings.Split(sql, ";"), 34, false)
 }
 
 /*func setPragmaFK(dbHandle *sql.DB, value string) error {

--- a/internal/dataprovider/sqlqueries.go
+++ b/internal/dataprovider/sqlqueries.go
@@ -797,10 +797,10 @@ func getClearGroupFolderMappingQuery() string {
 }
 
 func getAddGroupFolderMappingQuery() string {
-	return fmt.Sprintf(`INSERT INTO %s (virtual_path,quota_size,quota_files,folder_id,group_id,sort_order)
-		VALUES (%s,%s,%s,(SELECT id FROM %s WHERE name = %s),(SELECT id FROM %s WHERE name = %s),%s)`,
-		sqlTableGroupsFoldersMapping, sqlPlaceholders[0], sqlPlaceholders[1], sqlPlaceholders[2], sqlTableFolders,
-		sqlPlaceholders[3], getSQLQuotedName(sqlTableGroups), sqlPlaceholders[4], sqlPlaceholders[5])
+	return fmt.Sprintf(`INSERT INTO %s (virtual_path,subdirectory,quota_size,quota_files,folder_id,group_id,sort_order)
+		VALUES (%s,%s,%s,%s,(SELECT id FROM %s WHERE name = %s),(SELECT id FROM %s WHERE name = %s),%s)`,
+		sqlTableGroupsFoldersMapping, sqlPlaceholders[0], sqlPlaceholders[1], sqlPlaceholders[2], sqlPlaceholders[3], sqlTableFolders,
+		sqlPlaceholders[4], getSQLQuotedName(sqlTableGroups), sqlPlaceholders[5], sqlPlaceholders[6])
 }
 
 func getClearUserFolderMappingQuery() string {
@@ -809,10 +809,10 @@ func getClearUserFolderMappingQuery() string {
 }
 
 func getAddUserFolderMappingQuery() string {
-	return fmt.Sprintf(`INSERT INTO %s (virtual_path,quota_size,quota_files,folder_id,user_id,sort_order)
-		VALUES (%s,%s,%s,(SELECT id FROM %s WHERE name = %s),(SELECT id FROM %s WHERE username = %s),%s)`,
-		sqlTableUsersFoldersMapping, sqlPlaceholders[0], sqlPlaceholders[1], sqlPlaceholders[2], sqlTableFolders,
-		sqlPlaceholders[3], sqlTableUsers, sqlPlaceholders[4], sqlPlaceholders[5])
+	return fmt.Sprintf(`INSERT INTO %s (virtual_path,subdirectory,quota_size,quota_files,folder_id,user_id,sort_order)
+		VALUES (%s,%s,%s,%s,(SELECT id FROM %s WHERE name = %s),(SELECT id FROM %s WHERE username = %s),%s)`,
+		sqlTableUsersFoldersMapping, sqlPlaceholders[0], sqlPlaceholders[1], sqlPlaceholders[2], sqlPlaceholders[3], sqlTableFolders,
+		sqlPlaceholders[4], sqlTableUsers, sqlPlaceholders[5], sqlPlaceholders[6])
 }
 
 func getFoldersQuery(order string, minimal bool) string {
@@ -888,7 +888,7 @@ func getRelatedFoldersForUsersQuery(users []User) string {
 		sb.WriteString(")")
 	}
 	return fmt.Sprintf(`SELECT f.id,f.name,f.path,f.used_quota_size,f.used_quota_files,f.last_quota_update,fm.virtual_path,
-		fm.quota_size,fm.quota_files,fm.user_id,f.filesystem,f.description FROM %s f INNER JOIN %s fm ON f.id = fm.folder_id WHERE
+		fm.subdirectory,fm.quota_size,fm.quota_files,fm.user_id,f.filesystem,f.description FROM %s f INNER JOIN %s fm ON f.id = fm.folder_id WHERE
 		fm.user_id IN %s ORDER BY fm.sort_order`, sqlTableFolders, sqlTableUsersFoldersMapping, sb.String())
 }
 
@@ -905,7 +905,7 @@ func getRelatedUsersForFoldersQuery(folders []vfs.BaseVirtualFolder) string {
 	if sb.Len() > 0 {
 		sb.WriteString(")")
 	}
-	return fmt.Sprintf(`SELECT fm.folder_id,u.username FROM %s fm INNER JOIN %s u ON fm.user_id = u.id
+	return fmt.Sprintf(`SELECT DISTINCT fm.folder_id,u.username FROM %s fm INNER JOIN %s u ON fm.user_id = u.id
 		WHERE fm.folder_id IN %s ORDER BY u.username`, sqlTableUsersFoldersMapping, sqlTableUsers, sb.String())
 }
 
@@ -922,7 +922,7 @@ func getRelatedGroupsForFoldersQuery(folders []vfs.BaseVirtualFolder) string {
 	if sb.Len() > 0 {
 		sb.WriteString(")")
 	}
-	return fmt.Sprintf(`SELECT fm.folder_id,g.name FROM %s fm INNER JOIN %s g ON fm.group_id = g.id
+	return fmt.Sprintf(`SELECT DISTINCT fm.folder_id,g.name FROM %s fm INNER JOIN %s g ON fm.group_id = g.id
 		WHERE fm.folder_id IN %s ORDER BY g.name`, sqlTableGroupsFoldersMapping, getSQLQuotedName(sqlTableGroups),
 		sb.String())
 }
@@ -975,7 +975,7 @@ func getRelatedFoldersForGroupsQuery(groups []Group) string {
 		sb.WriteString(")")
 	}
 	return fmt.Sprintf(`SELECT f.id,f.name,f.path,f.used_quota_size,f.used_quota_files,f.last_quota_update,fm.virtual_path,
-		fm.quota_size,fm.quota_files,fm.group_id,f.filesystem,f.description FROM %s f INNER JOIN %s fm ON f.id = fm.folder_id WHERE
+		fm.subdirectory,fm.quota_size,fm.quota_files,fm.group_id,f.filesystem,f.description FROM %s f INNER JOIN %s fm ON f.id = fm.folder_id WHERE
 		fm.group_id IN %s ORDER BY fm.sort_order`, sqlTableFolders, sqlTableGroupsFoldersMapping, sb.String())
 }
 

--- a/internal/dataprovider/subdir_test.go
+++ b/internal/dataprovider/subdir_test.go
@@ -1,0 +1,143 @@
+// Copyright (C) 2026 Nicola Murino
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published
+// by the Free Software Foundation, version 3.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+package dataprovider
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/sftpgo/sdk"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/drakkan/sftpgo/v2/internal/vfs"
+)
+
+func TestNormalizeMappedSubdirectory(t *testing.T) {
+	for in, want := range map[string]string{
+		"simple":               "simple",
+		"level1/level2/level3": "level1/level2/level3",
+		"user_1/data-files":    "user_1/data-files",
+		"release..notes":       "release..notes",
+		"a//b/./c":             "a/b/c",
+		`tenant\data`:          "tenant/data", // backslash is treated as a separator
+		"":                     "",
+		".":                    "",
+	} {
+		got, err := normalizeMappedSubdirectory(in)
+		assert.NoError(t, err, "input %q", in)
+		assert.Equal(t, want, got, "input %q", in)
+	}
+	for _, in := range []string{"/absolute/path", "../parent", "valid/../../../escape", "..", `..\..\secrets`} {
+		_, err := normalizeMappedSubdirectory(in)
+		assert.ErrorIs(t, err, errInvalidMappedSubdirectory, "input %q", in)
+	}
+	// over-length is rejected (the column is part of a MySQL unique index)
+	_, err := normalizeMappedSubdirectory(strings.Repeat("a", 256))
+	assert.Error(t, err)
+	// an interior ".." that stays inside the root is collapsed, not rejected
+	got, err := normalizeMappedSubdirectory("path/with/../dots")
+	assert.NoError(t, err)
+	assert.Equal(t, "path/dots", got)
+}
+
+func TestValidateAssociatedVirtualFoldersSubdirectory(t *testing.T) {
+	// the same folder mapped to different subdirectories is allowed
+	folders, err := validateAssociatedVirtualFolders([]vfs.VirtualFolder{
+		{
+			BaseVirtualFolder:  vfs.BaseVirtualFolder{Name: "shared", MappedPath: "/data/shared"},
+			VirtualPath:        "/one",
+			MappedSubdirectory: "tenant1",
+		},
+		{
+			BaseVirtualFolder:  vfs.BaseVirtualFolder{Name: "shared", MappedPath: "/data/shared"},
+			VirtualPath:        "/two",
+			MappedSubdirectory: "tenant2/data",
+		},
+	})
+	require.NoError(t, err)
+	require.Len(t, folders, 2)
+	assert.Equal(t, "tenant1", folders[0].MappedSubdirectory)
+	assert.Equal(t, "tenant2/data", folders[1].MappedSubdirectory)
+	// only the folder name survives from the supplied BaseVirtualFolder
+	assert.Empty(t, folders[0].MappedPath)
+
+	// the same folder with the same subdirectory is a duplicate
+	_, err = validateAssociatedVirtualFolders([]vfs.VirtualFolder{
+		{BaseVirtualFolder: vfs.BaseVirtualFolder{Name: "shared"}, VirtualPath: "/one", MappedSubdirectory: "same"},
+		{BaseVirtualFolder: vfs.BaseVirtualFolder{Name: "shared"}, VirtualPath: "/two", MappedSubdirectory: "same"},
+	})
+	assert.Error(t, err)
+
+	_, err = validateAssociatedVirtualFolders([]vfs.VirtualFolder{
+		{BaseVirtualFolder: vfs.BaseVirtualFolder{Name: "shared"}, VirtualPath: "/one", MappedSubdirectory: "../escape"},
+	})
+	assert.Error(t, err)
+}
+
+func TestMappedSubdirectoryQuotaGuard(t *testing.T) {
+	_, err := validateAssociatedVirtualFolders([]vfs.VirtualFolder{
+		{
+			BaseVirtualFolder:  vfs.BaseVirtualFolder{Name: "shared"},
+			VirtualPath:        "/one",
+			MappedSubdirectory: "tenant1",
+			QuotaSize:          100,
+			QuotaFiles:         10,
+		},
+	})
+	assert.Error(t, err)
+	// unlimited (0/0) and included-in-user-quota (-1/-1) remain valid
+	for _, q := range [][2]int64{{0, 0}, {-1, -1}} {
+		_, err := validateAssociatedVirtualFolders([]vfs.VirtualFolder{
+			{
+				BaseVirtualFolder:  vfs.BaseVirtualFolder{Name: "shared"},
+				VirtualPath:        "/one",
+				MappedSubdirectory: "tenant1",
+				QuotaSize:          q[0],
+				QuotaFiles:         int(q[1]),
+			},
+		})
+		assert.NoError(t, err, "quota %v", q)
+	}
+}
+
+func TestVirtualFolderEffectiveMappedPath(t *testing.T) {
+	base := filepath.Join(string(filepath.Separator)+"data", "shared")
+	v := vfs.VirtualFolder{BaseVirtualFolder: vfs.BaseVirtualFolder{MappedPath: base}}
+	assert.Equal(t, base, v.GetEffectiveMappedPath())
+	v.MappedSubdirectory = "tenant1/data"
+	assert.Equal(t, filepath.Join(base, "tenant1", "data"), v.GetEffectiveMappedPath())
+}
+
+func TestGroupMappedSubdirectoryPlaceholder(t *testing.T) {
+	user := User{
+		BaseUser: sdk.BaseUser{Username: "alice"},
+		Groups:   []sdk.GroupMapping{{Name: "g", Type: sdk.GroupTypePrimary}},
+	}
+	group := Group{
+		BaseGroup: sdk.BaseGroup{Name: "g"},
+		VirtualFolders: []vfs.VirtualFolder{
+			{
+				BaseVirtualFolder:  vfs.BaseVirtualFolder{Name: "shared"},
+				VirtualPath:        "/data",
+				MappedSubdirectory: "%username%/files",
+			},
+		},
+	}
+	user.applyGroupSettings(map[string]Group{"g": group})
+	require.Len(t, user.VirtualFolders, 1)
+	assert.Equal(t, "alice/files", user.VirtualFolders[0].MappedSubdirectory)
+}

--- a/internal/dataprovider/user.go
+++ b/internal/dataprovider/user.go
@@ -178,11 +178,11 @@ func (u *User) GetFilesystem(connectionID string) (fs vfs.Fs, err error) {
 func (u *User) getRootFs(connectionID string) (fs vfs.Fs, err error) {
 	switch u.FsConfig.Provider {
 	case sdk.S3FilesystemProvider:
-		return vfs.NewS3Fs(connectionID, u.GetHomeDir(), "", u.FsConfig.S3Config)
+		return vfs.NewS3Fs(connectionID, u.GetHomeDir(), "", "", u.FsConfig.S3Config)
 	case sdk.GCSFilesystemProvider:
-		return vfs.NewGCSFs(connectionID, u.GetHomeDir(), "", u.FsConfig.GCSConfig)
+		return vfs.NewGCSFs(connectionID, u.GetHomeDir(), "", "", u.FsConfig.GCSConfig)
 	case sdk.AzureBlobFilesystemProvider:
-		return vfs.NewAzBlobFs(connectionID, u.GetHomeDir(), "", u.FsConfig.AzBlobConfig)
+		return vfs.NewAzBlobFs(connectionID, u.GetHomeDir(), "", "", u.FsConfig.AzBlobConfig)
 	case sdk.CryptedFilesystemProvider:
 		return vfs.NewCryptFs(connectionID, u.GetHomeDir(), "", u.FsConfig.CryptConfig)
 	case sdk.SFTPFilesystemProvider:
@@ -191,9 +191,9 @@ func (u *User) getRootFs(connectionID string) (fs vfs.Fs, err error) {
 			return nil, err
 		}
 		forbiddenSelfUsers = append(forbiddenSelfUsers, u.Username)
-		return vfs.NewSFTPFs(connectionID, "", u.GetHomeDir(), forbiddenSelfUsers, u.FsConfig.SFTPConfig)
+		return vfs.NewSFTPFs(connectionID, "", "", u.GetHomeDir(), forbiddenSelfUsers, u.FsConfig.SFTPConfig)
 	case sdk.HTTPFilesystemProvider:
-		return vfs.NewHTTPFs(connectionID, u.GetHomeDir(), "", u.FsConfig.HTTPConfig)
+		return vfs.NewHTTPFs(connectionID, u.GetHomeDir(), "", "", u.FsConfig.HTTPConfig)
 	default:
 		return vfs.NewOsFs(connectionID, u.GetHomeDir(), "", &u.FsConfig.OSConfig), nil
 	}
@@ -341,6 +341,9 @@ func (u *User) isFsEqual(other *User) bool {
 			f1 := &other.VirtualFolders[idx1]
 			if f.VirtualPath == f1.VirtualPath {
 				found = true
+				if f.MappedSubdirectory != f1.MappedSubdirectory {
+					return false
+				}
 				if f.FsConfig.Provider == sdk.LocalFilesystemProvider && f.MappedPath != f1.MappedPath {
 					return false
 				}
@@ -843,7 +846,7 @@ func (u *User) FilterListDir(dirContents []os.FileInfo, virtualPath string) []os
 func (u *User) IsMappedPath(fsPath string) bool {
 	for idx := range u.VirtualFolders {
 		v := &u.VirtualFolders[idx]
-		if fsPath == v.MappedPath {
+		if fsPath == v.MappedPath || fsPath == v.GetEffectiveMappedPath() {
 			return true
 		}
 	}
@@ -1745,6 +1748,7 @@ func (u *User) mergeVirtualFolders(group *Group, groupType int, replacer *string
 			folder.VirtualPath = u.replacePlaceholder(folder.VirtualPath, replacer)
 			if _, ok := folderPaths[folder.VirtualPath]; !ok {
 				folder.MappedPath = u.replacePlaceholder(folder.MappedPath, replacer)
+				folder.MappedSubdirectory = u.replacePlaceholder(folder.MappedSubdirectory, replacer)
 				folder.FsConfig = u.replaceFsConfigPlaceholders(folder.FsConfig, replacer)
 				u.VirtualFolders = append(u.VirtualFolders, folder)
 			}

--- a/internal/httpd/httpd_test.go
+++ b/internal/httpd/httpd_test.go
@@ -6152,6 +6152,73 @@ func TestUserFolderMapping(t *testing.T) {
 	assert.NoError(t, err)
 }
 
+func TestUserFolderMappingWithSubdirectory(t *testing.T) {
+	baseMappedPath := filepath.Join(os.TempDir(), "subdir_mapping_test")
+	err := os.MkdirAll(baseMappedPath, os.ModePerm)
+	assert.NoError(t, err)
+	defer os.RemoveAll(baseMappedPath)
+
+	folderName := "shared_mapping_folder"
+	f := vfs.BaseVirtualFolder{
+		Name:       folderName,
+		MappedPath: baseMappedPath,
+	}
+	_, _, err = httpdtest.AddFolder(f, http.StatusCreated)
+	assert.NoError(t, err)
+
+	users := []struct {
+		username string
+		subdir   string
+		vpath    string
+	}{
+		{"mapping_user1", "tenant1/data", "/data"},
+		{"mapping_user2", "tenant2/data", "/data"},
+		{"mapping_user3", "", "/shared"},
+	}
+
+	var createdUsers []dataprovider.User
+
+	for _, userInfo := range users {
+		u := getTestUser()
+		u.Username = userInfo.username
+		u.VirtualFolders = []vfs.VirtualFolder{
+			{
+				BaseVirtualFolder: vfs.BaseVirtualFolder{
+					Name: folderName,
+				},
+				VirtualPath:        userInfo.vpath,
+				MappedSubdirectory: userInfo.subdir,
+			},
+		}
+
+		user, _, err := httpdtest.AddUser(u, http.StatusCreated)
+		assert.NoError(t, err)
+		createdUsers = append(createdUsers, user)
+	}
+
+	folder, _, err := httpdtest.GetFolderByName(folderName, http.StatusOK)
+	assert.NoError(t, err)
+	assert.Len(t, folder.Users, 3)
+
+	for _, userInfo := range users {
+		user, _, err := httpdtest.GetUserByUsername(userInfo.username, http.StatusOK)
+		assert.NoError(t, err)
+		if assert.Len(t, user.VirtualFolders, 1) {
+			vf := user.VirtualFolders[0]
+			assert.Equal(t, userInfo.subdir, vf.MappedSubdirectory)
+			assert.Equal(t, userInfo.vpath, vf.VirtualPath)
+			assert.Equal(t, folderName, vf.Name)
+		}
+	}
+
+	for _, user := range createdUsers {
+		_, err = httpdtest.RemoveUser(user, http.StatusOK)
+		assert.NoError(t, err)
+	}
+	_, err = httpdtest.RemoveFolder(vfs.BaseVirtualFolder{Name: folderName}, http.StatusOK)
+	assert.NoError(t, err)
+}
+
 func TestUserS3Config(t *testing.T) {
 	user, _, err := httpdtest.AddUser(getTestUser(), http.StatusCreated)
 	assert.NoError(t, err)
@@ -8307,6 +8374,116 @@ func TestFolders(t *testing.T) {
 	assert.NoError(t, err)
 	_, err = httpdtest.RemoveFolder(folder2, http.StatusOK)
 	assert.NoError(t, err)
+}
+
+func TestVirtualFolderSubdirectoryValidation(t *testing.T) {
+	mappedPath := filepath.Join(os.TempDir(), "subdir_validation")
+	folderName := "test_subdir_folder"
+
+	f := vfs.BaseVirtualFolder{
+		Name:       folderName,
+		MappedPath: mappedPath,
+	}
+	folder, _, err := httpdtest.AddFolder(f, http.StatusCreated)
+	assert.NoError(t, err)
+	defer httpdtest.RemoveFolder(folder, http.StatusOK)
+
+	testCases := []struct {
+		name           string
+		subdirectory   string
+		expectedStatus int
+	}{
+		{"valid_simple", "simple", http.StatusCreated},
+		{"valid_nested", "level1/level2/level3", http.StatusCreated},
+		{"valid_empty", "", http.StatusCreated},
+		{"invalid_absolute", "/absolute/path", http.StatusBadRequest},
+		{"invalid_parent_traversal", "../escape", http.StatusBadRequest},
+		{"invalid_embedded_traversal", "valid/../../../escape", http.StatusBadRequest},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			u := getTestUser()
+			u.Username = fmt.Sprintf("subdir_test_%s", tc.name)
+			u.VirtualFolders = []vfs.VirtualFolder{
+				{
+					BaseVirtualFolder: vfs.BaseVirtualFolder{
+						Name: folderName,
+					},
+					VirtualPath:        "/test",
+					MappedSubdirectory: tc.subdirectory,
+				},
+			}
+
+			user, resp, err := httpdtest.AddUser(u, tc.expectedStatus)
+			assert.NoError(t, err, string(resp))
+			if tc.expectedStatus == http.StatusCreated {
+				_, err = httpdtest.RemoveUser(user, http.StatusOK)
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestVirtualFolderSubdirectoryDuplication(t *testing.T) {
+	mappedPath := filepath.Join(os.TempDir(), "dup_validation")
+	folderName := "dup_test_folder"
+
+	f := vfs.BaseVirtualFolder{
+		Name:       folderName,
+		MappedPath: mappedPath,
+	}
+	folder, _, err := httpdtest.AddFolder(f, http.StatusCreated)
+	assert.NoError(t, err)
+	defer httpdtest.RemoveFolder(folder, http.StatusOK)
+
+	u := getTestUser()
+	u.Username = "dup_test_user"
+	u.VirtualFolders = []vfs.VirtualFolder{
+		{
+			BaseVirtualFolder: vfs.BaseVirtualFolder{
+				Name: folderName,
+			},
+			VirtualPath:        "/folder1",
+			MappedSubdirectory: "subdir1",
+		},
+		{
+			BaseVirtualFolder: vfs.BaseVirtualFolder{
+				Name: folderName,
+			},
+			VirtualPath:        "/folder2",
+			MappedSubdirectory: "subdir2",
+		},
+	}
+
+	// the same folder mapped to different subdirectories is allowed
+	user, resp, err := httpdtest.AddUser(u, http.StatusCreated)
+	assert.NoError(t, err, string(resp))
+	defer httpdtest.RemoveUser(user, http.StatusOK)
+
+	u2 := getTestUser()
+	u2.Username = "dup_test_user2"
+	u2.VirtualFolders = []vfs.VirtualFolder{
+		{
+			BaseVirtualFolder: vfs.BaseVirtualFolder{
+				Name: folderName,
+			},
+			VirtualPath:        "/path1",
+			MappedSubdirectory: "same_subdir",
+		},
+		{
+			BaseVirtualFolder: vfs.BaseVirtualFolder{
+				Name: folderName,
+			},
+			VirtualPath:        "/path2",
+			MappedSubdirectory: "same_subdir",
+		},
+	}
+
+	// the same folder with the same subdirectory is a duplicate
+	_, resp, err = httpdtest.AddUser(u2, http.StatusBadRequest)
+	assert.NoError(t, err, string(resp))
+	assert.Contains(t, string(resp), "duplicated")
 }
 
 func TestFolderRelations(t *testing.T) {

--- a/internal/httpd/webadmin.go
+++ b/internal/httpd/webadmin.go
@@ -1254,6 +1254,7 @@ func getVirtualFoldersFromPostFields(r *http.Request) []vfs.VirtualFolder {
 	var virtualFolders []vfs.VirtualFolder
 	folderPaths := r.Form["vfolder_path"]
 	folderNames := r.Form["vfolder_name"]
+	folderSubdirectories := r.Form["vfolder_mapped_subdirectory"]
 	folderQuotaSizes := r.Form["vfolder_quota_size"]
 	folderQuotaFiles := r.Form["vfolder_quota_files"]
 	for idx, p := range folderPaths {
@@ -1269,6 +1270,9 @@ func getVirtualFoldersFromPostFields(r *http.Request) []vfs.VirtualFolder {
 				VirtualPath: p,
 				QuotaFiles:  -1,
 				QuotaSize:   -1,
+			}
+			if len(folderSubdirectories) > idx {
+				vfolder.MappedSubdirectory = strings.TrimSpace(folderSubdirectories[idx])
 			}
 			if len(folderQuotaSizes) > idx {
 				quotaSize, err := util.ParseBytes(folderQuotaSizes[idx])
@@ -2019,6 +2023,7 @@ func updateRepeaterFormFields(r *http.Request) {
 			base, _ := strings.CutSuffix(k, "[vfolder_path]")
 			r.Form.Add("vfolder_path", strings.TrimSpace(r.Form.Get(k)))
 			r.Form.Add("vfolder_name", strings.TrimSpace(r.Form.Get(base+"[vfolder_name]")))
+			r.Form.Add("vfolder_mapped_subdirectory", strings.TrimSpace(r.Form.Get(base+"[vfolder_mapped_subdirectory]")))
 			r.Form.Add("vfolder_quota_files", strings.TrimSpace(r.Form.Get(base+"[vfolder_quota_files]")))
 			r.Form.Add("vfolder_quota_size", strings.TrimSpace(r.Form.Get(base+"[vfolder_quota_size]")))
 			continue

--- a/internal/sftpd/sftpd_test.go
+++ b/internal/sftpd/sftpd_test.go
@@ -9073,20 +9073,29 @@ func TestRootDirCommands(t *testing.T) {
 func TestRelativePaths(t *testing.T) {
 	user := getTestUser(true)
 	var path, rel string
-	filesystems := []vfs.Fs{vfs.NewOsFs("", user.GetHomeDir(), "", nil)}
+	subDir := "samplesubdir"
+	subdirPath := filepath.Join(user.GetHomeDir(), subDir)
+	err := os.MkdirAll(subdirPath, os.ModePerm)
+	assert.NoError(t, err)
+	defer os.RemoveAll(subdirPath)
+	filesystems := []vfs.Fs{
+		vfs.NewOsFs("", user.GetHomeDir(), "", nil),
+		// a filesystem scoped to a subdirectory is simply rooted there
+		vfs.NewOsFs("", subdirPath, "", nil),
+	}
 	keyPrefix := strings.TrimPrefix(user.GetHomeDir(), "/") + "/"
 	s3config := vfs.S3FsConfig{
 		BaseS3FsConfig: sdk.BaseS3FsConfig{
 			KeyPrefix: keyPrefix,
 		},
 	}
-	s3fs, _ := vfs.NewS3Fs("", user.GetHomeDir(), "", s3config)
+	s3fs, _ := vfs.NewS3Fs("", user.GetHomeDir(), "", "", s3config)
 	gcsConfig := vfs.GCSFsConfig{
 		BaseGCSFsConfig: sdk.BaseGCSFsConfig{
 			KeyPrefix: keyPrefix,
 		},
 	}
-	gcsfs, _ := vfs.NewGCSFs("", user.GetHomeDir(), "", gcsConfig)
+	gcsfs, _ := vfs.NewGCSFs("", user.GetHomeDir(), "", "", gcsConfig)
 	sftpconfig := vfs.SFTPFsConfig{
 		BaseSFTPFsConfig: sdk.BaseSFTPFsConfig{
 			Endpoint: sftpServerAddr,
@@ -9095,42 +9104,44 @@ func TestRelativePaths(t *testing.T) {
 		},
 		Password: kms.NewPlainSecret(defaultPassword),
 	}
-	sftpfs, _ := vfs.NewSFTPFs("", "", os.TempDir(), []string{user.Username}, sftpconfig)
+	sftpfs, _ := vfs.NewSFTPFs("", "", "", os.TempDir(), []string{user.Username}, sftpconfig)
 	if runtime.GOOS != osWindows {
 		filesystems = append(filesystems, s3fs, gcsfs, sftpfs)
 	}
-	rootPath := "/"
-	for _, fs := range filesystems {
-		path = filepath.Join(user.HomeDir, "/")
-		rel = fs.GetRelativePath(path)
-		assert.Equal(t, rootPath, rel)
-		path = filepath.Join(user.HomeDir, "//")
-		rel = fs.GetRelativePath(path)
-		assert.Equal(t, rootPath, rel)
-		path = filepath.Join(user.HomeDir, "../..")
-		rel = fs.GetRelativePath(path)
-		assert.Equal(t, rootPath, rel)
-		path = filepath.Join(user.HomeDir, "../../../../../")
-		rel = fs.GetRelativePath(path)
-		assert.Equal(t, rootPath, rel)
-		path = filepath.Join(user.HomeDir, "/..")
-		rel = fs.GetRelativePath(path)
-		assert.Equal(t, rootPath, rel)
-		path = filepath.Join(user.HomeDir, "/../../../..")
-		rel = fs.GetRelativePath(path)
-		assert.Equal(t, rootPath, rel)
-		path = filepath.Join(user.HomeDir, "")
-		rel = fs.GetRelativePath(path)
-		assert.Equal(t, rootPath, rel)
-		path = filepath.Join(user.HomeDir, ".")
-		rel = fs.GetRelativePath(path)
-		assert.Equal(t, rootPath, rel)
-		path = filepath.Join(user.HomeDir, "somedir")
-		rel = fs.GetRelativePath(path)
-		assert.Equal(t, "/somedir", rel)
-		path = filepath.Join(user.HomeDir, "/somedir/subdir")
-		rel = fs.GetRelativePath(path)
-		assert.Equal(t, "/somedir/subdir", rel)
+	rootPaths := []string{"/", "//", "../..", "../../../../../", "/..", "/../../../..", "", "."}
+	for i, fs := range filesystems {
+		isSubDirFs := i == 1 // Second filesystem is the subdir OsFs
+		for _, rootPath := range rootPaths {
+			path = filepath.Join(user.HomeDir, rootPath)
+			rel = fs.GetRelativePath(path)
+			assert.Equal(t, "/", rel, "fs %d: %s", i, rootPath)
+		}
+		testPaths := []struct{ input, expected string }{
+			{"somedir", "/somedir"},
+			{"somedir/file.txt", "/somedir/file.txt"},
+			{filepath.Join("somedir", "subdir"), "/somedir/subdir"},
+		}
+		for _, test := range testPaths {
+			path = filepath.Join(user.HomeDir, test.input)
+			rel = fs.GetRelativePath(path)
+			if isSubDirFs {
+				assert.Equal(t, "/", rel, "fs %d subdir (outside): %s", i, test.input)
+			} else {
+				assert.Equal(t, test.expected, rel, "fs %d: %s", i, test.input)
+			}
+		}
+		if isSubDirFs {
+			subDirTests := []struct{ input, expected string }{
+				{subDir, "/"},
+				{filepath.Join(subDir, "file.txt"), "/file.txt"},
+				{filepath.Join(subDir, "nested", "deep.txt"), "/nested/deep.txt"},
+			}
+			for _, test := range subDirTests {
+				path = filepath.Join(user.HomeDir, test.input)
+				rel = fs.GetRelativePath(path)
+				assert.Equal(t, test.expected, rel, "fs %d subdir (inside): %s", i, test.input)
+			}
+		}
 	}
 }
 
@@ -9149,14 +9160,14 @@ func TestResolvePaths(t *testing.T) {
 	}
 	err = os.MkdirAll(user.GetHomeDir(), os.ModePerm)
 	assert.NoError(t, err)
-	s3fs, err := vfs.NewS3Fs("", user.GetHomeDir(), "", s3config)
+	s3fs, _ := vfs.NewS3Fs("", user.GetHomeDir(), "", "", s3config)
 	assert.NoError(t, err)
 	gcsConfig := vfs.GCSFsConfig{
 		BaseGCSFsConfig: sdk.BaseGCSFsConfig{
 			KeyPrefix: keyPrefix,
 		},
 	}
-	gcsfs, _ := vfs.NewGCSFs("", user.GetHomeDir(), "", gcsConfig)
+	gcsfs, _ := vfs.NewGCSFs("", user.GetHomeDir(), "", "", gcsConfig)
 	if runtime.GOOS != osWindows {
 		filesystems = append(filesystems, s3fs, gcsfs)
 	}

--- a/internal/vfs/azblobfs.go
+++ b/internal/vfs/azblobfs.go
@@ -66,6 +66,7 @@ type AzureBlobFs struct {
 	localTempDir string
 	// if not empty this fs is mouted as virtual folder in the specified path
 	mountPath       string
+	subDir          string
 	config          *AzBlobFsConfig
 	containerClient *container.Client
 	ctxTimeout      time.Duration
@@ -77,13 +78,14 @@ func init() {
 }
 
 // NewAzBlobFs returns an AzBlobFs object that allows to interact with Azure Blob storage
-func NewAzBlobFs(connectionID, localTempDir, mountPath string, config AzBlobFsConfig) (Fs, error) {
+func NewAzBlobFs(connectionID, localTempDir, subDir, mountPath string, config AzBlobFsConfig) (Fs, error) {
 	if localTempDir == "" {
 		localTempDir = getLocalTempDir()
 	}
 	fs := &AzureBlobFs{
 		connectionID:   connectionID,
 		localTempDir:   localTempDir,
+		subDir:         subDir,
 		mountPath:      getMountPath(mountPath),
 		config:         &config,
 		ctxTimeout:     30 * time.Second,
@@ -185,7 +187,7 @@ func (fs *AzureBlobFs) Stat(name string) (os.FileInfo, error) {
 	if name == "" || name == "/" || name == "." {
 		return NewFileInfo(name, true, 0, time.Unix(0, 0), false), nil
 	}
-	if fs.config.KeyPrefix == name+"/" {
+	if fs.effectivePrefix() == name+"/" {
 		return NewFileInfo(name, true, 0, time.Unix(0, 0), false), nil
 	}
 
@@ -535,7 +537,7 @@ func (fs *AzureBlobFs) CheckRootPath(username string, uid int, gid int) bool {
 // ScanRootDirContents returns the number of files contained in the bucket,
 // and their size
 func (fs *AzureBlobFs) ScanRootDirContents() (int, int64, error) {
-	return fs.GetDirSize(fs.config.KeyPrefix)
+	return fs.GetDirSize(fs.effectivePrefix())
 }
 
 // GetDirSize returns the number of files and the size for a folder
@@ -597,11 +599,11 @@ func (fs *AzureBlobFs) GetRelativePath(name string) string {
 	if !path.IsAbs(rel) {
 		rel = "/" + rel
 	}
-	if fs.config.KeyPrefix != "" {
-		if !strings.HasPrefix(rel, "/"+fs.config.KeyPrefix) {
+	if prefix := fs.effectivePrefix(); prefix != "" {
+		if !strings.HasPrefix(rel, "/"+prefix) {
 			rel = "/"
 		}
-		rel = path.Clean("/" + strings.TrimPrefix(rel, "/"+fs.config.KeyPrefix))
+		rel = path.Clean("/" + strings.TrimPrefix(rel, "/"+prefix))
 	}
 	if fs.mountPath != "" {
 		rel = path.Join(fs.mountPath, rel)
@@ -676,7 +678,18 @@ func (fs *AzureBlobFs) ResolvePath(virtualPath string) (string, error) {
 		}
 	}
 	virtualPath = path.Clean("/" + virtualPath)
-	return fs.Join(fs.config.KeyPrefix, strings.TrimPrefix(virtualPath, "/")), nil
+	return fs.Join(fs.effectivePrefix(), strings.TrimPrefix(virtualPath, "/")), nil
+}
+
+func (fs *AzureBlobFs) effectivePrefix() string {
+	if fs.subDir == "" {
+		return fs.config.KeyPrefix
+	}
+	prefix := path.Join(fs.config.KeyPrefix, fs.subDir)
+	if prefix == "" || prefix == "/" {
+		return ""
+	}
+	return strings.TrimPrefix(prefix, "/") + "/"
 }
 
 // CopyFile implements the FsFileCopier interface

--- a/internal/vfs/azblobfs_disabled.go
+++ b/internal/vfs/azblobfs_disabled.go
@@ -27,6 +27,6 @@ func init() {
 }
 
 // NewAzBlobFs returns an error, Azure Blob storage is disabled
-func NewAzBlobFs(_, _, _ string, _ AzBlobFsConfig) (Fs, error) {
+func NewAzBlobFs(_, _, _, _ string, _ AzBlobFsConfig) (Fs, error) {
 	return nil, errors.New("Azure Blob Storage disabled at build time")
 }

--- a/internal/vfs/folder.go
+++ b/internal/vfs/folder.go
@@ -17,6 +17,7 @@ package vfs
 import (
 	"errors"
 	"fmt"
+	"path/filepath"
 	"strings"
 
 	"github.com/rs/xid"
@@ -107,7 +108,6 @@ func (v *BaseVirtualFolder) HasRedactedSecret() bool {
 
 // hasPathPlaceholder returns true if the folder has a path placeholder
 func (v *BaseVirtualFolder) hasPathPlaceholder() bool {
-	placeholders := []string{"%username%", "%role%"}
 	var config string
 	switch v.FsConfig.Provider {
 	case sdk.S3FilesystemProvider:
@@ -121,8 +121,12 @@ func (v *BaseVirtualFolder) hasPathPlaceholder() bool {
 	case sdk.LocalFilesystemProvider, sdk.CryptedFilesystemProvider:
 		config = v.MappedPath
 	}
-	for _, placeholder := range placeholders {
-		if strings.Contains(config, placeholder) {
+	return hasPathPlaceholder(config)
+}
+
+func hasPathPlaceholder(value string) bool {
+	for _, placeholder := range []string{"%username%", "%role%"} {
+		if strings.Contains(value, placeholder) {
 			return true
 		}
 	}
@@ -138,35 +142,46 @@ func (v *BaseVirtualFolder) hasPathPlaceholder() bool {
 type VirtualFolder struct {
 	BaseVirtualFolder
 	VirtualPath string `json:"virtual_path"`
+	// Optional relative subdirectory that narrows this folder to a subtree of the backing storage
+	MappedSubdirectory string `json:"mapped_subdirectory,omitempty"`
 	// Maximum size allowed as bytes. 0 means unlimited, -1 included in user quota
 	QuotaSize int64 `json:"quota_size"`
 	// Maximum number of files allowed. 0 means unlimited, -1 included in user quota
 	QuotaFiles int `json:"quota_files"`
 }
 
+// GetEffectiveMappedPath returns the mapped path narrowed by the mapped
+// subdirectory. It is meaningful only for local and crypted filesystems.
+func (v *VirtualFolder) GetEffectiveMappedPath() string {
+	if v.MappedSubdirectory == "" {
+		return v.MappedPath
+	}
+	return filepath.Join(v.MappedPath, filepath.FromSlash(v.MappedSubdirectory))
+}
+
 // GetFilesystem returns the filesystem for this folder
 func (v *VirtualFolder) GetFilesystem(connectionID string, forbiddenSelfUsers []string) (Fs, error) {
 	switch v.FsConfig.Provider {
 	case sdk.S3FilesystemProvider:
-		return NewS3Fs(connectionID, v.MappedPath, v.VirtualPath, v.FsConfig.S3Config)
+		return NewS3Fs(connectionID, v.MappedPath, v.MappedSubdirectory, v.VirtualPath, v.FsConfig.S3Config)
 	case sdk.GCSFilesystemProvider:
-		return NewGCSFs(connectionID, v.MappedPath, v.VirtualPath, v.FsConfig.GCSConfig)
+		return NewGCSFs(connectionID, v.MappedPath, v.MappedSubdirectory, v.VirtualPath, v.FsConfig.GCSConfig)
 	case sdk.AzureBlobFilesystemProvider:
-		return NewAzBlobFs(connectionID, v.MappedPath, v.VirtualPath, v.FsConfig.AzBlobConfig)
+		return NewAzBlobFs(connectionID, v.MappedPath, v.MappedSubdirectory, v.VirtualPath, v.FsConfig.AzBlobConfig)
 	case sdk.CryptedFilesystemProvider:
-		return NewCryptFs(connectionID, v.MappedPath, v.VirtualPath, v.FsConfig.CryptConfig)
+		return NewCryptFs(connectionID, v.GetEffectiveMappedPath(), v.VirtualPath, v.FsConfig.CryptConfig)
 	case sdk.SFTPFilesystemProvider:
-		return NewSFTPFs(connectionID, v.VirtualPath, v.MappedPath, forbiddenSelfUsers, v.FsConfig.SFTPConfig)
+		return NewSFTPFs(connectionID, v.VirtualPath, v.MappedSubdirectory, v.MappedPath, forbiddenSelfUsers, v.FsConfig.SFTPConfig)
 	case sdk.HTTPFilesystemProvider:
-		return NewHTTPFs(connectionID, v.MappedPath, v.VirtualPath, v.FsConfig.HTTPConfig)
+		return NewHTTPFs(connectionID, v.MappedPath, v.MappedSubdirectory, v.VirtualPath, v.FsConfig.HTTPConfig)
 	default:
-		return NewOsFs(connectionID, v.MappedPath, v.VirtualPath, &v.FsConfig.OSConfig), nil
+		return NewOsFs(connectionID, v.GetEffectiveMappedPath(), v.VirtualPath, &v.FsConfig.OSConfig), nil
 	}
 }
 
 // ScanQuota scans the folder and returns the number of files and their size
 func (v *VirtualFolder) ScanQuota() (int, int64, error) {
-	if v.hasPathPlaceholder() {
+	if v.hasPathPlaceholder() || hasPathPlaceholder(v.MappedSubdirectory) {
 		return 0, 0, errors.New("cannot scan quota: this folder has a path placeholder")
 	}
 	fs, err := v.GetFilesystem(xid.New().String(), nil)
@@ -194,9 +209,10 @@ func (v *VirtualFolder) HasNoQuotaRestrictions(checkFiles bool) bool {
 // GetACopy returns a copy
 func (v *VirtualFolder) GetACopy() VirtualFolder {
 	return VirtualFolder{
-		BaseVirtualFolder: v.BaseVirtualFolder.GetACopy(),
-		VirtualPath:       v.VirtualPath,
-		QuotaSize:         v.QuotaSize,
-		QuotaFiles:        v.QuotaFiles,
+		BaseVirtualFolder:  v.BaseVirtualFolder.GetACopy(),
+		VirtualPath:        v.VirtualPath,
+		MappedSubdirectory: v.MappedSubdirectory,
+		QuotaSize:          v.QuotaSize,
+		QuotaFiles:         v.QuotaFiles,
 	}
 }

--- a/internal/vfs/gcsfs.go
+++ b/internal/vfs/gcsfs.go
@@ -57,6 +57,7 @@ type GCSFs struct {
 	localTempDir string
 	// if not empty this fs is mouted as virtual folder in the specified path
 	mountPath      string
+	subDir         string
 	config         *GCSFsConfig
 	svc            *storage.Client
 	ctxTimeout     time.Duration
@@ -68,7 +69,7 @@ func init() {
 }
 
 // NewGCSFs returns an GCSFs object that allows to interact with Google Cloud Storage
-func NewGCSFs(connectionID, localTempDir, mountPath string, config GCSFsConfig) (Fs, error) {
+func NewGCSFs(connectionID, localTempDir, subDir, mountPath string, config GCSFsConfig) (Fs, error) {
 	if localTempDir == "" {
 		localTempDir = getLocalTempDir()
 	}
@@ -77,6 +78,7 @@ func NewGCSFs(connectionID, localTempDir, mountPath string, config GCSFsConfig) 
 	fs := &GCSFs{
 		connectionID:   connectionID,
 		localTempDir:   localTempDir,
+		subDir:         subDir,
 		mountPath:      getMountPath(mountPath),
 		config:         &config,
 		ctxTimeout:     30 * time.Second,
@@ -120,7 +122,7 @@ func (fs *GCSFs) Stat(name string) (os.FileInfo, error) {
 	if name == "" || name == "/" || name == "." {
 		return NewFileInfo(name, true, 0, time.Unix(0, 0), false), nil
 	}
-	if fs.config.KeyPrefix == name+"/" {
+	if fs.effectivePrefix() == name+"/" {
 		return NewFileInfo(name, true, 0, time.Unix(0, 0), false), nil
 	}
 	return fs.getObjectStat(name)
@@ -475,7 +477,7 @@ func (fs *GCSFs) CheckRootPath(username string, uid int, gid int) bool {
 // ScanRootDirContents returns the number of files contained in the bucket,
 // and their size
 func (fs *GCSFs) ScanRootDirContents() (int, int64, error) {
-	return fs.GetDirSize(fs.config.KeyPrefix)
+	return fs.GetDirSize(fs.effectivePrefix())
 }
 
 // GetDirSize returns the number of files and the size for a folder
@@ -551,11 +553,11 @@ func (fs *GCSFs) GetRelativePath(name string) string {
 	if !path.IsAbs(rel) {
 		rel = "/" + rel
 	}
-	if fs.config.KeyPrefix != "" {
-		if !strings.HasPrefix(rel, "/"+fs.config.KeyPrefix) {
+	if prefix := fs.effectivePrefix(); prefix != "" {
+		if !strings.HasPrefix(rel, "/"+prefix) {
 			rel = "/"
 		}
-		rel = path.Clean("/" + strings.TrimPrefix(rel, "/"+fs.config.KeyPrefix))
+		rel = path.Clean("/" + strings.TrimPrefix(rel, "/"+prefix))
 	}
 	if fs.mountPath != "" {
 		rel = path.Join(fs.mountPath, rel)
@@ -645,7 +647,18 @@ func (fs *GCSFs) ResolvePath(virtualPath string) (string, error) {
 		}
 	}
 	virtualPath = path.Clean("/" + virtualPath)
-	return fs.Join(fs.config.KeyPrefix, strings.TrimPrefix(virtualPath, "/")), nil
+	return fs.Join(fs.effectivePrefix(), strings.TrimPrefix(virtualPath, "/")), nil
+}
+
+func (fs *GCSFs) effectivePrefix() string {
+	if fs.subDir == "" {
+		return fs.config.KeyPrefix
+	}
+	prefix := path.Join(fs.config.KeyPrefix, fs.subDir)
+	if prefix == "" || prefix == "/" {
+		return ""
+	}
+	return strings.TrimPrefix(prefix, "/") + "/"
 }
 
 // CopyFile implements the FsFileCopier interface

--- a/internal/vfs/gcsfs_disabled.go
+++ b/internal/vfs/gcsfs_disabled.go
@@ -27,6 +27,6 @@ func init() {
 }
 
 // NewGCSFs returns an error, GCS is disabled
-func NewGCSFs(_, _, _ string, _ GCSFsConfig) (Fs, error) {
+func NewGCSFs(_, _, _, _ string, _ GCSFsConfig) (Fs, error) {
 	return nil, errors.New("Google Cloud Storage disabled at build time")
 }

--- a/internal/vfs/httpfs.go
+++ b/internal/vfs/httpfs.go
@@ -199,13 +199,14 @@ type HTTPFs struct {
 	localTempDir string
 	// if not empty this fs is mouted as virtual folder in the specified path
 	mountPath  string
+	subDir     string
 	config     *HTTPFsConfig
 	client     *http.Client
 	ctxTimeout time.Duration
 }
 
 // NewHTTPFs returns an HTTPFs object that allows to interact with SFTPGo HTTP filesystem backends
-func NewHTTPFs(connectionID, localTempDir, mountPath string, config HTTPFsConfig) (Fs, error) {
+func NewHTTPFs(connectionID, localTempDir, subDir, mountPath string, config HTTPFsConfig) (Fs, error) {
 	if localTempDir == "" {
 		localTempDir = getLocalTempDir()
 	}
@@ -223,6 +224,7 @@ func NewHTTPFs(connectionID, localTempDir, mountPath string, config HTTPFsConfig
 	fs := &HTTPFs{
 		connectionID: connectionID,
 		localTempDir: localTempDir,
+		subDir:       subDir,
 		mountPath:    mountPath,
 		config:       &config,
 		ctxTimeout:   30 * time.Second,
@@ -552,9 +554,9 @@ func (*HTTPFs) IsNotSupported(err error) bool {
 	return err == ErrVfsUnsupported
 }
 
-// CheckRootPath creates the specified local root directory if it does not exists
+// CheckRootPath creates the local directory for temporary files. The remote
+// root, including any mapped subdirectory, must already exist on the server.
 func (fs *HTTPFs) CheckRootPath(username string, uid int, gid int) bool {
-	// we need a local directory for temporary files
 	osFs := NewOsFs(fs.ConnectionID(), fs.localTempDir, "", nil)
 	defer osFs.Close() //nolint:errcheck
 
@@ -563,7 +565,7 @@ func (fs *HTTPFs) CheckRootPath(username string, uid int, gid int) bool {
 
 // ScanRootDirContents returns the number of files and their size
 func (fs *HTTPFs) ScanRootDirContents() (int, int64, error) {
-	return fs.GetDirSize("/")
+	return fs.GetDirSize(fs.effectiveRoot())
 }
 
 // CheckMetadata checks the metadata consistency
@@ -611,6 +613,13 @@ func (fs *HTTPFs) GetRelativePath(name string) string {
 	if !path.IsAbs(rel) {
 		rel = "/" + rel
 	}
+	if root := fs.effectiveRoot(); root != "/" {
+		if !strings.HasPrefix(rel, root+"/") && rel != root {
+			rel = "/"
+		} else {
+			rel = path.Clean("/" + strings.TrimPrefix(rel, root))
+		}
+	}
 	if fs.mountPath != "" {
 		rel = path.Join(fs.mountPath, rel)
 	}
@@ -644,7 +653,14 @@ func (fs *HTTPFs) ResolvePath(virtualPath string) (string, error) {
 			virtualPath = after
 		}
 	}
-	return path.Clean("/" + virtualPath), nil
+	return path.Join(fs.effectiveRoot(), path.Clean("/"+virtualPath)), nil
+}
+
+func (fs *HTTPFs) effectiveRoot() string {
+	if fs.subDir == "" {
+		return "/"
+	}
+	return path.Clean("/" + fs.subDir)
 }
 
 // GetMimeType returns the content type

--- a/internal/vfs/s3fs.go
+++ b/internal/vfs/s3fs.go
@@ -74,6 +74,7 @@ type S3Fs struct {
 	localTempDir string
 	// if not empty this fs is mouted as virtual folder in the specified path
 	mountPath         string
+	subDir            string
 	config            *S3FsConfig
 	svc               *s3.Client
 	ctxTimeout        time.Duration
@@ -88,13 +89,14 @@ func init() {
 
 // NewS3Fs returns an S3Fs object that allows to interact with an s3 compatible
 // object storage
-func NewS3Fs(connectionID, localTempDir, mountPath string, s3Config S3FsConfig) (Fs, error) {
+func NewS3Fs(connectionID, localTempDir, subDir, mountPath string, s3Config S3FsConfig) (Fs, error) {
 	if localTempDir == "" {
 		localTempDir = getLocalTempDir()
 	}
 	fs := &S3Fs{
 		connectionID: connectionID,
 		localTempDir: localTempDir,
+		subDir:       subDir,
 		mountPath:    getMountPath(mountPath),
 		config:       &s3Config,
 		ctxTimeout:   30 * time.Second,
@@ -178,7 +180,7 @@ func (fs *S3Fs) Stat(name string) (os.FileInfo, error) {
 	if name == "" || name == "/" || name == "." {
 		return NewFileInfo(name, true, 0, time.Unix(0, 0), false), nil
 	}
-	if fs.config.KeyPrefix == name+"/" {
+	if fs.effectivePrefix() == name+"/" {
 		return NewFileInfo(name, true, 0, time.Unix(0, 0), false), nil
 	}
 	obj, err := fs.headObject(name)
@@ -491,7 +493,7 @@ func (fs *S3Fs) CheckRootPath(username string, uid int, gid int) bool {
 // ScanRootDirContents returns the number of files contained in the bucket,
 // and their size
 func (fs *S3Fs) ScanRootDirContents() (int, int64, error) {
-	return fs.GetDirSize(fs.config.KeyPrefix)
+	return fs.GetDirSize(fs.effectivePrefix())
 }
 
 // GetDirSize returns the number of files and the size for a folder
@@ -548,11 +550,11 @@ func (fs *S3Fs) GetRelativePath(name string) string {
 	if !path.IsAbs(rel) {
 		rel = "/" + rel
 	}
-	if fs.config.KeyPrefix != "" {
-		if !strings.HasPrefix(rel, "/"+fs.config.KeyPrefix) {
+	if prefix := fs.effectivePrefix(); prefix != "" {
+		if !strings.HasPrefix(rel, "/"+prefix) {
 			rel = "/"
 		}
-		rel = path.Clean("/" + strings.TrimPrefix(rel, "/"+fs.config.KeyPrefix))
+		rel = path.Clean("/" + strings.TrimPrefix(rel, "/"+prefix))
 	}
 	if fs.mountPath != "" {
 		rel = path.Join(fs.mountPath, rel)
@@ -618,7 +620,18 @@ func (fs *S3Fs) ResolvePath(virtualPath string) (string, error) {
 		}
 	}
 	virtualPath = path.Clean("/" + virtualPath)
-	return fs.Join(fs.config.KeyPrefix, strings.TrimPrefix(virtualPath, "/")), nil
+	return fs.Join(fs.effectivePrefix(), strings.TrimPrefix(virtualPath, "/")), nil
+}
+
+func (fs *S3Fs) effectivePrefix() string {
+	if fs.subDir == "" {
+		return fs.config.KeyPrefix
+	}
+	prefix := path.Join(fs.config.KeyPrefix, fs.subDir)
+	if prefix == "" || prefix == "/" {
+		return ""
+	}
+	return strings.TrimPrefix(prefix, "/") + "/"
 }
 
 // CopyFile implements the FsFileCopier interface

--- a/internal/vfs/sftpfs.go
+++ b/internal/vfs/sftpfs.go
@@ -310,13 +310,14 @@ type SFTPFs struct {
 	connectionID string
 	// if not empty this fs is mouted as virtual folder in the specified path
 	mountPath    string
+	subDir       string
 	localTempDir string
 	config       *SFTPFsConfig
 	conn         *sftpConnection
 }
 
 // NewSFTPFs returns an SFTPFs object that allows to interact with an SFTP server
-func NewSFTPFs(connectionID, mountPath, localTempDir string, forbiddenSelfUsernames []string, config SFTPFsConfig) (Fs, error) {
+func NewSFTPFs(connectionID, mountPath, subDir, localTempDir string, forbiddenSelfUsernames []string, config SFTPFsConfig) (Fs, error) {
 	if localTempDir == "" {
 		localTempDir = getLocalTempDir()
 	}
@@ -346,6 +347,7 @@ func NewSFTPFs(connectionID, mountPath, localTempDir string, forbiddenSelfUserna
 	sftpFs := &SFTPFs{
 		connectionID: connectionID,
 		mountPath:    getMountPath(mountPath),
+		subDir:       subDir,
 		localTempDir: localTempDir,
 		config:       &config,
 		conn:         conn,
@@ -647,15 +649,16 @@ func (fs *SFTPFs) CheckRootPath(username string, uid int, gid int) bool {
 	defer osFs.Close() //nolint:errcheck
 
 	osFs.CheckRootPath(username, uid, gid)
-	if fs.config.Prefix == "/" {
+	prefix := fs.effectivePrefix()
+	if prefix == "/" {
 		return true
 	}
 	client, err := fs.conn.getClient()
 	if err != nil {
 		return false
 	}
-	if err := client.MkdirAll(fs.config.Prefix); err != nil {
-		fsLog(fs, logger.LevelDebug, "error creating root directory %q for user %q: %v", fs.config.Prefix, username, err)
+	if err := client.MkdirAll(prefix); err != nil {
+		fsLog(fs, logger.LevelDebug, "error creating root directory %q for user %q: %v", prefix, username, err)
 		return false
 	}
 	return true
@@ -664,7 +667,7 @@ func (fs *SFTPFs) CheckRootPath(username string, uid int, gid int) bool {
 // ScanRootDirContents returns the number of files contained in a directory and
 // their size
 func (fs *SFTPFs) ScanRootDirContents() (int, int64, error) {
-	return fs.GetDirSize(fs.config.Prefix)
+	return fs.GetDirSize(fs.effectivePrefix())
 }
 
 // CheckMetadata checks the metadata consistency
@@ -686,22 +689,23 @@ func (fs *SFTPFs) GetRelativePath(name string) string {
 	if rel == "." {
 		rel = ""
 	}
+	prefix := fs.effectivePrefix()
 	if !path.IsAbs(rel) {
 		// If we have a relative path we assume it is already relative to the virtual root
 		rel = "/" + rel
-	} else if fs.config.Prefix != "/" {
-		prefixDir := fs.config.Prefix
+	} else if prefix != "/" {
+		prefixDir := prefix
 		if !strings.HasSuffix(prefixDir, "/") {
 			prefixDir += "/"
 		}
 
-		if rel == fs.config.Prefix {
+		if rel == prefix {
 			rel = "/"
 		} else if after, found := strings.CutPrefix(rel, prefixDir); found {
 			rel = path.Clean("/" + after)
 		} else {
 			// Absolute path outside of the configured prefix
-			fsLog(fs, logger.LevelWarn, "path %q is an absolute path outside %q", name, fs.config.Prefix)
+			fsLog(fs, logger.LevelWarn, "path %q is an absolute path outside %q", name, prefix)
 			rel = "/"
 		}
 	}
@@ -750,8 +754,9 @@ func (fs *SFTPFs) ResolvePath(virtualPath string) (string, error) {
 		}
 	}
 	virtualPath = path.Clean("/" + virtualPath)
-	fsPath := fs.Join(fs.config.Prefix, virtualPath)
-	if fs.config.Prefix != "/" && fsPath != "/" {
+	prefix := fs.effectivePrefix()
+	fsPath := fs.Join(prefix, virtualPath)
+	if prefix != "/" && fsPath != "/" {
 		validatedPath, err := fs.canonicalRealPath(fsPath)
 		if err != nil {
 			fsLog(fs, logger.LevelError, "Invalid path resolution, original path %q resolved %q err: %v",
@@ -778,7 +783,7 @@ func (fs *SFTPFs) RealPath(p string) (string, error) {
 		return "", err
 	}
 	resolved = path.Clean(strings.ReplaceAll(resolved, "\\", "/"))
-	if fs.config.Prefix != "/" {
+	if fs.effectivePrefix() != "/" {
 		if err := fs.isSubDir(resolved); err != nil {
 			fsLog(fs, logger.LevelError, "Invalid real path resolution, original path %q resolved %q err: %v",
 				p, resolved, err)
@@ -796,7 +801,7 @@ func (fs *SFTPFs) canonicalRealPath(name string) (string, error) { //nolint:gocy
 	name = path.Clean("/" + strings.ReplaceAll(name, "\\", "/"))
 	resolved := "/"
 	var rest []string
-	if prefix := fs.config.Prefix; prefix != "" && prefix != "/" {
+	if prefix := fs.effectivePrefix(); prefix != "" && prefix != "/" {
 		if name == prefix {
 			return prefix, nil
 		}
@@ -853,18 +858,26 @@ func (fs *SFTPFs) canonicalRealPath(name string) (string, error) { //nolint:gocy
 }
 
 func (fs *SFTPFs) isSubDir(name string) error {
-	if name == fs.config.Prefix {
+	prefix := fs.effectivePrefix()
+	if name == prefix {
 		return nil
 	}
-	if len(name) < len(fs.config.Prefix) {
-		err := fmt.Errorf("path %q is not inside: %q", name, fs.config.Prefix)
+	if len(name) < len(prefix) {
+		err := fmt.Errorf("path %q is not inside: %q", name, prefix)
 		return &pathResolutionError{err: err.Error()}
 	}
-	if !strings.HasPrefix(name, fs.config.Prefix+"/") {
-		err := fmt.Errorf("path %q is not inside: %q", name, fs.config.Prefix)
+	if !strings.HasPrefix(name, prefix+"/") {
+		err := fmt.Errorf("path %q is not inside: %q", name, prefix)
 		return &pathResolutionError{err: err.Error()}
 	}
 	return nil
+}
+
+func (fs *SFTPFs) effectivePrefix() string {
+	if fs.subDir == "" {
+		return fs.config.Prefix
+	}
+	return util.CleanPath(path.Join(fs.config.Prefix, fs.subDir))
 }
 
 // GetDirSize returns the number of files and the size for a folder

--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -5769,6 +5769,9 @@ components:
           properties:
             virtual_path:
               type: string
+            mapped_subdirectory:
+              type: string
+              description: 'Optional relative subdirectory that scopes this folder to a subtree of the backing storage, so users can share a base folder while each is isolated to its own subdirectory. Independent positive quotas are not supported when set.'
             quota_size:
               type: integer
               format: int64

--- a/static/locales/en/translation.json
+++ b/static/locales/en/translation.json
@@ -566,6 +566,8 @@
     "virtual_folders": {
         "view_manage": "View and manage virtual folders",
         "mount_path": "mount path, i.e. /vfolder",
+        "subdirectory": "mapped subdirectory within storage (optional)",
+        "subdirectory_help": "Scopes this folder to a subtree of the shared storage. Independent positive quotas are not supported when set.",
         "quota_size": "Quota size",
         "quota_size_help": "0 means no limit. You can use MB/GB/TB suffix",
         "quota_files": "Quota files",

--- a/templates/webadmin/group.html
+++ b/templates/webadmin/group.html
@@ -55,10 +55,10 @@ explicit grant from the SFTPGo Team (support@sftpgo.com).
                                 <div data-repeater-item>
                                     <div data-repeater-item>
                                         <div class="form-group row">
-                                            <div class="col-md-3 mt-3 mt-md-8">
+                                            <div class="col-md-2 mt-3 mt-md-8">
                                                 <input data-i18n="[placeholder]virtual_folders.mount_path" type="text" class="form-control" name="vfolder_path" value="{{$val.VirtualPath}}" />
                                             </div>
-                                            <div class="col-md-3 mt-3 mt-md-8">
+                                            <div class="col-md-2 mt-3 mt-md-8">
                                                 <select name="vfolder_name" data-i18n="[data-placeholder]general.folder_placeholder" class="form-select select-repetear" data-placeholder="Select a folder" data-allow-clear="true">
                                                     <option value=""></option>
                                                     {{- range $.VirtualFolders}}
@@ -66,7 +66,11 @@ explicit grant from the SFTPGo Team (support@sftpgo.com).
                                                     {{- end}}
                                                 </select>
                                             </div>
-                                            <div class="col-md-3 mt-3 mt-md-8">
+                                            <div class="col-md-2 mt-3 mt-md-8">
+                                                <input data-i18n="[placeholder]virtual_folders.subdirectory" type="text" class="form-control" name="vfolder_mapped_subdirectory" value="{{$val.MappedSubdirectory}}" />
+                                                <div class="form-text" data-i18n="virtual_folders.subdirectory_help"></div>
+                                            </div>
+                                            <div class="col-md-2 mt-3 mt-md-8">
                                                 <input type="text" class="form-control" name="vfolder_quota_size" value="{{HumanizeBytes $val.QuotaSize}}" />
                                                 <div class="form-text" data-i18n="virtual_folders.quota_size"></div>
                                             </div>
@@ -74,9 +78,8 @@ explicit grant from the SFTPGo Team (support@sftpgo.com).
                                                 <input type="number" min="-1" class="form-control" name="vfolder_quota_files" value="{{$val.QuotaFiles}}" />
                                                 <div class="form-text" data-i18n="virtual_folders.quota_files"></div>
                                             </div>
-                                            <div class="col-md-1 mt-3 mt-md-8">
-                                                <a href="#" data-repeater-delete
-                                                    class="btn btn-light-danger ps-5 pe-4">
+                                            <div class="col-md-2 mt-3 mt-md-8">
+                                                <a href="#" data-repeater-delete class="btn btn-light-danger ps-5 pe-4">
                                                     <i class="ki-duotone ki-trash fs-2">
                                                         <span class="path1"></span>
                                                         <span class="path2"></span>
@@ -92,10 +95,10 @@ explicit grant from the SFTPGo Team (support@sftpgo.com).
                                 {{- else}}
                                 <div data-repeater-item>
                                     <div class="form-group row">
-                                        <div class="col-md-3 mt-3 mt-md-8">
+                                        <div class="col-md-2 mt-3 mt-md-8">
                                             <input data-i18n="[placeholder]virtual_folders.mount_path" type="text" class="form-control" name="vfolder_path" value="" />
                                         </div>
-                                        <div class="col-md-3 mt-3 mt-md-8">
+                                        <div class="col-md-2 mt-3 mt-md-8">
                                             <select name="vfolder_name" data-i18n="[data-placeholder]general.folder_placeholder" class="form-select select-repetear" data-placeholder="Select a folder" data-allow-clear="true">
                                                 <option value=""></option>
                                                 {{- range .VirtualFolders}}
@@ -103,7 +106,11 @@ explicit grant from the SFTPGo Team (support@sftpgo.com).
                                                 {{- end}}
                                             </select>
                                         </div>
-                                        <div class="col-md-3 mt-3 mt-md-8">
+                                        <div class="col-md-2 mt-3 mt-md-8">
+                                            <input data-i18n="[placeholder]virtual_folders.subdirectory" type="text" class="form-control" name="vfolder_mapped_subdirectory" value="" />
+                                            <div class="form-text" data-i18n="virtual_folders.subdirectory_help"></div>
+                                        </div>
+                                        <div class="col-md-2 mt-3 mt-md-8">
                                             <input type="text" class="form-control" name="vfolder_quota_size" value="" />
                                             <div class="form-text" data-i18n="virtual_folders.quota_size"></div>
                                         </div>
@@ -111,7 +118,7 @@ explicit grant from the SFTPGo Team (support@sftpgo.com).
                                             <input type="number" min="-1" class="form-control" name="vfolder_quota_files" value="" />
                                             <div class="form-text" data-i18n="virtual_folders.quota_files"></div>
                                         </div>
-                                        <div class="col-md-1 mt-3 mt-md-8">
+                                        <div class="col-md-2 mt-3 mt-md-8">
                                             <a href="#" data-repeater-delete
                                                 class="btn btn-light-danger ps-5 pe-4">
                                                 <i class="ki-duotone ki-trash fs-2">

--- a/templates/webadmin/user.html
+++ b/templates/webadmin/user.html
@@ -347,10 +347,10 @@ explicit grant from the SFTPGo Team (support@sftpgo.com).
                                 <div data-repeater-item>
                                     <div data-repeater-item>
                                         <div class="form-group row">
-                                            <div class="col-md-3 mt-3 mt-md-8">
+                                            <div class="col-md-2 mt-3 mt-md-8">
                                                 <input data-i18n="[placeholder]virtual_folders.mount_path" type="text" class="form-control" name="vfolder_path" value="{{$val.VirtualPath}}" />
                                             </div>
-                                            <div class="col-md-3 mt-3 mt-md-8">
+                                            <div class="col-md-2 mt-3 mt-md-8">
                                                 <select name="vfolder_name" data-i18n="[data-placeholder]general.folder_placeholder" class="form-select select-repetear" data-placeholder="Select a folder" data-allow-clear="true">
                                                     <option value=""></option>
                                                     {{- range $.VirtualFolders}}
@@ -358,7 +358,11 @@ explicit grant from the SFTPGo Team (support@sftpgo.com).
                                                     {{- end}}
                                                 </select>
                                             </div>
-                                            <div class="col-md-3 mt-3 mt-md-8">
+                                            <div class="col-md-2 mt-3 mt-md-8">
+                                                <input data-i18n="[placeholder]virtual_folders.subdirectory" type="text" class="form-control" name="vfolder_mapped_subdirectory" value="{{$val.MappedSubdirectory}}" />
+                                                <div class="form-text" data-i18n="virtual_folders.subdirectory_help"></div>
+                                            </div>
+                                            <div class="col-md-2 mt-3 mt-md-8">
                                                 <input type="text" class="form-control" name="vfolder_quota_size" value="{{HumanizeBytes $val.QuotaSize}}" />
                                                 <div class="form-text" data-i18n="virtual_folders.quota_size"></div>
                                             </div>
@@ -366,7 +370,7 @@ explicit grant from the SFTPGo Team (support@sftpgo.com).
                                                 <input type="number" min="-1" class="form-control" name="vfolder_quota_files" value="{{$val.QuotaFiles}}" />
                                                 <div class="form-text" data-i18n="virtual_folders.quota_files"></div>
                                             </div>
-                                            <div class="col-md-1 mt-3 mt-md-8">
+                                            <div class="col-md-2 mt-3 mt-md-8">
                                                 <a href="#" data-repeater-delete
                                                     class="btn btn-light-danger ps-5 pe-4">
                                                     <i class="ki-duotone ki-trash fs-2">
@@ -384,10 +388,10 @@ explicit grant from the SFTPGo Team (support@sftpgo.com).
                                 {{- else}}
                                 <div data-repeater-item>
                                     <div class="form-group row">
-                                        <div class="col-md-3 mt-3 mt-md-8">
+                                        <div class="col-md-2 mt-3 mt-md-8">
                                             <input data-i18n="[placeholder]virtual_folders.mount_path" type="text" class="form-control" name="vfolder_path" value="" />
                                         </div>
-                                        <div class="col-md-3 mt-3 mt-md-8">
+                                        <div class="col-md-2 mt-3 mt-md-8">
                                             <select name="vfolder_name" data-i18n="[data-placeholder]general.folder_placeholder" class="form-select select-repetear" data-placeholder="Select a folder" data-allow-clear="true">
                                                 <option value=""></option>
                                                 {{- range .VirtualFolders}}
@@ -395,7 +399,11 @@ explicit grant from the SFTPGo Team (support@sftpgo.com).
                                                 {{- end}}
                                             </select>
                                         </div>
-                                        <div class="col-md-3 mt-3 mt-md-8">
+                                        <div class="col-md-2 mt-3 mt-md-8">
+                                            <input data-i18n="[placeholder]virtual_folders.subdirectory" type="text" class="form-control" name="vfolder_mapped_subdirectory" value="" />
+                                            <div class="form-text" data-i18n="virtual_folders.subdirectory_help"></div>
+                                        </div>
+                                        <div class="col-md-2 mt-3 mt-md-8">
                                             <input type="text" class="form-control" name="vfolder_quota_size" value="" />
                                             <div class="form-text" data-i18n="virtual_folders.quota_size"></div>
                                         </div>
@@ -403,7 +411,7 @@ explicit grant from the SFTPGo Team (support@sftpgo.com).
                                             <input type="number" min="-1" class="form-control" name="vfolder_quota_files" value="" />
                                             <div class="form-text" data-i18n="virtual_folders.quota_files"></div>
                                         </div>
-                                        <div class="col-md-1 mt-3 mt-md-8">
+                                        <div class="col-md-2 mt-3 mt-md-8">
                                             <a href="#" data-repeater-delete
                                                 class="btn btn-light-danger ps-5 pe-4">
                                                 <i class="ki-duotone ki-trash fs-2">


### PR DESCRIPTION
Hello!

Thanks for all the work on SFTPGo, it's been difficult to find a good hobbyist solution for exposing some file storage on a NAS with my family. I've read your comments on the difficulty in getting fairly compensated, and I hope the open core model goes well!

### Preamble

In my own usage, I've been trying to set up new-user creation with virtual folders to access content managed by other applications (photos, document uploads, etc.), I've found the inability to specify sub-directories of a virtual folder that should be mapped to a user's tree to be quite inconvenient.

Since this is just a small extension to the filesystem code and data model, I felt like I could give implementing this a shot myself with a bit of help from `grep` and LLMs to make sure I don't miss anything in a codebase I'm unfamiliar with. This seems to have gone fairly well, and I've tested the database upgrade + functionality on my NAS.

### Feature description

Allow virtual folders to map to subdirectories within shared storage, enabling better user isolation and multi-tenant setups.

When configuring a virtual folder, users can now specify a 'virtual_subdirectory' that automatically isolates their access within a shared storage location. For example, multiple users can share the same base folder while each accessing their own subdirectory.

### New UI demo

<img width="1581" height="1120" alt="image" src="https://github.com/user-attachments/assets/471998da-a44f-4014-836c-2cba73d46e5a" />

### Checklist for Pull Requests

- [x] Have you signed the [Contributor License Agreement](https://sftpgo.com/cla.html)?