### PR TITLE
feat: add TLS cipher suite logging for all protocols

### DIFF
--- a/internal/ftpd/server.go
+++ b/internal/ftpd/server.go
@@ -322,6 +322,15 @@ func (s *Server) VerifyTLSConnectionState(_ ftpserver.ClientContext, cs tls.Conn
 }
 
 func (s *Server) verifyTLSConnection(state tls.ConnectionState) error {
+	// Log the negotiated TLS cipher suite for each new connection
+	cipherName := util.GetTLSCipherSuiteName(state.CipherSuite)
+	clientInfo := "unknown"
+	if len(state.PeerCertificates) > 0 {
+		clientInfo = state.PeerCertificates[0].Subject.CommonName
+	}
+	logger.Info(logSender, "", "new TLS connection from %v, cipher: %s, TLS version: %s",
+		clientInfo, cipherName, tls.VersionName(state.Version))
+
 	if certMgr != nil {
 		var clientCrt *x509.Certificate
 		var clientCrtName string

--- a/internal/httpd/server.go
+++ b/internal/httpd/server.go
@@ -134,6 +134,15 @@ func (s *httpdServer) listenAndServe() error {
 }
 
 func (s *httpdServer) verifyTLSConnection(state tls.ConnectionState) error {
+	// Log the negotiated TLS cipher suite for each new connection
+	cipherName := util.GetTLSCipherSuiteName(state.CipherSuite)
+	clientInfo := "unknown"
+	if len(state.PeerCertificates) > 0 {
+		clientInfo = state.PeerCertificates[0].Subject.CommonName
+	}
+	logger.Info(logSender, "", "new TLS connection from %v, cipher: %s, TLS version: %s",
+		clientInfo, cipherName, tls.VersionName(state.Version))
+
 	if certMgr != nil {
 		var clientCrt *x509.Certificate
 		var clientCrtName string

--- a/internal/util/util.go
+++ b/internal/util/util.go
@@ -648,6 +648,21 @@ func GetTLSCiphersFromNames(cipherNames []string) []uint16 {
 	return ciphers
 }
 
+// GetTLSCipherSuiteName returns the TLS cipher suite name from the specified ID
+func GetTLSCipherSuiteName(cipherID uint16) string {
+	for _, c := range tls.CipherSuites() {
+		if c.ID == cipherID {
+			return c.Name
+		}
+	}
+	for _, c := range tls.InsecureCipherSuites() {
+		if c.ID == cipherID {
+			return c.Name
+		}
+	}
+	return fmt.Sprintf("Unknown(0x%04x)", cipherID)
+}
+
 // GetALPNProtocols returns the ALPN protocols, any invalid protocol will be
 // silently ignored. If no protocol or no valid protocol is provided the default
 // is http/1.1, h2

--- a/internal/webdavd/server.go
+++ b/internal/webdavd/server.go
@@ -108,6 +108,15 @@ func (s *webDavServer) listenAndServe(compressor *middleware.Compressor) error {
 }
 
 func (s *webDavServer) verifyTLSConnection(state tls.ConnectionState) error {
+	// Log the negotiated TLS cipher suite for each new connection
+	cipherName := util.GetTLSCipherSuiteName(state.CipherSuite)
+	clientInfo := "unknown"
+	if len(state.PeerCertificates) > 0 {
+		clientInfo = state.PeerCertificates[0].Subject.CommonName
+	}
+	logger.Info(logSender, "", "new TLS connection from %v, cipher: %s, TLS version: %s",
+		clientInfo, cipherName, tls.VersionName(state.Version))
+
 	if certMgr != nil {
 		var clientCrt *x509.Certificate
 		var clientCrtName string


### PR DESCRIPTION
## Description
Adds comprehensive TLS cipher suite and version logging for all TLS-enabled protocols in SFTPGo.

## Changes
- Added `GetTLSCipherSuiteName` utility function for readable cipher names
- Enhanced HTTP/HTTPS, FTP/FTPS, and WebDAV/WebDAVS servers with TLS connection logging
- Logs include negotiated cipher suite and TLS version for each new connection
- Handles edge cases where client certificates are not present

## Example Logs

[INFO] [httpd] new TLS connection from client.example.com, cipher: TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384, TLS version: TLS 1.3 [INFO] [ftpd] new TLS connection from unknown, cipher: TLS_AES_128_GCM_SHA256, TLS version: TLS 1.3

## Benefits
- Improved security monitoring and auditing capabilities
- Better visibility into TLS connection parameters
- Helps with debugging TLS-related issues