### PR TITLE
bugfix: stat s3 common prefix

### DIFF
--- a/internal/vfs/s3fs.go
+++ b/internal/vfs/s3fs.go
@@ -786,9 +786,10 @@ func (fs *S3Fs) hasContents(name string) (bool, error) {
 	prefix := fs.getPrefix(name)
 	maxKeys := int32(2)
 	paginator := s3.NewListObjectsV2Paginator(fs.svc, &s3.ListObjectsV2Input{
-		Bucket:  aws.String(fs.config.Bucket),
-		Prefix:  aws.String(prefix),
-		MaxKeys: &maxKeys,
+		Bucket:    aws.String(fs.config.Bucket),
+		Prefix:    aws.String(prefix),
+		Delimiter: aws.String("/"),
+		MaxKeys:   &maxKeys,
 	})
 
 	if paginator.HasMorePages() {
@@ -806,6 +807,9 @@ func (fs *S3Fs) hasContents(name string) (bool, error) {
 			if name == "" || name == "/" {
 				continue
 			}
+			return true, nil
+		}
+		if len(page.CommonPrefixes) > 0 {
 			return true, nil
 		}
 		return false, nil


### PR DESCRIPTION
# Checklist for Pull Requests

- [x] Have you signed the [Contributor License Agreement](https://sftpgo.com/cla.html)?

---
**Description**
<img width="1224" height="803" alt="image" src="https://github.com/user-attachments/assets/c77f45e8-8d5d-41af-8422-b33dc5d3d72a" />
Directories automatically created via the S3 protocol are returned as common prefixes during list queries. However, some S3 implementations do not support HEAD requests for common prefixes, and empty common prefixes are not automatically removed when objects are deleted. In such cases, when performing a stat operation, both the headObject and getStatForDir functions will return errors, making it necessary to rely on the hasContents function to correctly identify directories (common prefixes). However, when a directory (common prefix) contains only subdirectories (also common prefixes) and no objects, this function fails to work correctly. As a result, the directory (common prefix) cannot be properly removed (rm) or accessed (cd).