### PR TITLE
Add fix for SSH_FXP_STAT with S3 backend during file upload

### DIFF
--- a/internal/common/common.go
+++ b/internal/common/common.go
@@ -463,6 +463,7 @@ type ActiveTransfer interface {
 	GetDownloadedSize() int64
 	GetUploadedSize() int64
 	GetVirtualPath() string
+	GetFsPath() string
 	GetStartTime() time.Time
 	SignalClose(err error)
 	Truncate(fsPath string, size int64) (int64, error)

--- a/internal/httpd/handler.go
+++ b/internal/httpd/handler.go
@@ -306,6 +306,10 @@ func (t *throttledReader) GetVirtualPath() string {
 	return "**reading request body**"
 }
 
+func (t *throttledReader) GetFsPath() string {
+	return ""
+}
+
 func (t *throttledReader) GetStartTime() time.Time {
 	return t.start
 }

--- a/internal/vfs/vfs.go
+++ b/internal/vfs/vfs.go
@@ -1071,6 +1071,14 @@ func IsLocalOrSFTPFs(fs Fs) bool {
 	return IsLocalOsFs(fs) || IsSFTPFs(fs)
 }
 
+// IsS3Fs returns true if fs is S3
+func IsS3Fs(fs Fs) bool {
+	if fs == nil {
+		return false
+	}
+	return strings.HasPrefix(fs.Name(), s3fsName)
+}
+
 // HasTruncateSupport returns true if the fs supports truncate files
 func HasTruncateSupport(fs Fs) bool {
 	return IsLocalOsFs(fs) || IsSFTPFs(fs) || IsHTTPFs(fs)


### PR DESCRIPTION
This fixes an issue with S3 backed virtual folders where the SFTP client tries to retrieve SSH_FXP_STAT while the file is still open for writing. The implemented fix checks whether there is a file upload to S3 in progress and then returns a valid SSH_FXP_STAT response to the SFTP client.

Fixes  #2010 

# Checklist for Pull Requests

- [x] Have you signed the [Contributor License Agreement](https://sftpgo.com/cla.html)?

# Testing

The following python script was used for testing the behavior. Make sure to configure an S3 backed virtual folder under `mys3virtualfolder` in the users home directory. I used uv to run the test. Also make sure to configure SFTPGo to ignore stat changes (`setstat_mode` set to `1`)

```
go run main.go serve --log-level debug --config-file sftpgo.yaml
uv run test_stat_during_upload.py --host localhost --port 2022 --username <username> --password <password> --path mys3virtualfolder/testfile
```

```yaml
common:
  setstat_mode: 1
```

`test_stat_during_upload.py`: https://gist.github.com/jstudler/123c15740e48637fa40fe3e31ab4a16e

edit 2026-01-22: move test_stat_during_upload.py to gist to reduce size of PR description