### PR TITLE
Support LATIN1 encoding on FTP paths

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -67,6 +67,7 @@ require (
 	golang.org/x/oauth2 v0.34.0
 	golang.org/x/sys v0.39.0
 	golang.org/x/term v0.38.0
+	golang.org/x/text v0.32.0
 	golang.org/x/time v0.14.0
 	google.golang.org/api v0.257.0
 	gopkg.in/natefinch/lumberjack.v2 v2.2.1
@@ -169,7 +170,6 @@ require (
 	go.yaml.in/yaml/v3 v3.0.4 // indirect
 	golang.org/x/mod v0.31.0 // indirect
 	golang.org/x/sync v0.19.0 // indirect
-	golang.org/x/text v0.32.0 // indirect
 	golang.org/x/tools v0.40.0 // indirect
 	golang.org/x/xerrors v0.0.0-20240903120638-7835f813f4da // indirect
 	google.golang.org/genproto v0.0.0-20251222181119-0a764e51fe1b // indirect

--- a/internal/ftpd/handler_test.go
+++ b/internal/ftpd/handler_test.go
@@ -1,0 +1,36 @@
+package ftpd
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/drakkan/sftpgo/v2/internal/common"
+	"github.com/drakkan/sftpgo/v2/internal/dataprovider"
+)
+
+func TestNormalizeFTPPathLatin1(t *testing.T) {
+	conn := &Connection{
+		BaseConnection: common.NewBaseConnection("test-conn", common.ProtocolFTP, "127.0.0.1", "127.0.0.1",
+			dataprovider.User{}),
+	}
+	latin1 := string([]byte{0x66, 0x6f, 0x6f, 0xe9, 0x2e, 0x74, 0x78, 0x74})
+
+	normalized, err := conn.normalizeFTPPath(latin1)
+
+	require.NoError(t, err)
+	require.Equal(t, "fooé.txt", normalized)
+}
+
+func TestNormalizeFTPPathUTF8(t *testing.T) {
+	conn := &Connection{
+		BaseConnection: common.NewBaseConnection("test-conn", common.ProtocolFTP, "127.0.0.1", "127.0.0.1",
+			dataprovider.User{}),
+	}
+	utf8Name := "déjà-vu.txt"
+
+	normalized, err := conn.normalizeFTPPath(utf8Name)
+
+	require.NoError(t, err)
+	require.Equal(t, utf8Name, normalized)
+}


### PR DESCRIPTION
Possible fix to the LATIN1 encoding support for FTP server (https://github.com/drakkan/sftpgo/discussions/2169).

Disclaimer: I asked Codex to do the work, I am not a Go dev.

# Checklist for Pull Requests

- [x] Have you signed the [Contributor License Agreement](https://sftpgo.com/cla.html)?

---
