### PR TITLE
httpd: auto-redirect to change password page on mandatory password ch…

### DIFF
--- a/internal/httpd/server.go
+++ b/internal/httpd/server.go
@@ -772,6 +772,10 @@ func (s *httpdServer) loginUser(
 	}
 	updateLoginMetrics(user, dataprovider.LoginMethodPassword, ipAddr, err, r)
 	dataprovider.UpdateLastLogin(user)
+	if user.MustChangePassword() {
+		http.Redirect(w, r, webChangeClientPwdPath, http.StatusFound)
+		return
+	}
 	if next := r.URL.Query().Get("next"); strings.HasPrefix(next, webClientFilesPath) {
 		http.Redirect(w, r, next, http.StatusFound)
 		return
@@ -816,6 +820,10 @@ func (s *httpdServer) loginAdmin(
 	}
 	dataprovider.UpdateAdminLastLogin(admin)
 	common.DelayLogin(nil)
+	if admin.Filters.RequirePasswordChange {
+		http.Redirect(w, r, webChangeAdminPwdPath, http.StatusFound)
+		return
+	}
 	redirectURL := webUsersPath
 	if errorFunc == nil {
 		redirectURL = webAdminMFAPath


### PR DESCRIPTION
# Checklist for Pull Requests

- [ ] Have you signed the [Contributor License Agreement](https://sftpgo.com/cla.html)?

---
## Auto-Redirect to Change Password Page on Mandatory Password Change

### Summary

This PR adds a focused improvement to the WebUI login flow:
when a user or admin is required to change their password, they are now
automatically redirected to the change password page immediately after
a successful login.

> **Note on Turkish locale:** We have submitted the Turkish ([tr](cci:1://file:///Users/orhangazibasli/Desktop/Paylasim/Project/sftpgo/internal/httpd/server.go:1231:0-1237:1)) language
> translation separately via [Crowdin](https://crowdin.com/project/sftpgo)
> as suggested. It is **not** included in this PR.

---

### Problem

When `MustChangePassword` (user) or `RequirePasswordChange` (admin) was set,
after a successful login the user was redirected to the normal landing page
(`/web/client/files` or `/web/admin/users`).
The `checkAuthRequirements` middleware would then block every subsequent
request with a **Forbidden** error, leaving the user with no visible path
forward and no indication of what they needed to do.

### Solution

Added an explicit redirect to the change password page immediately after
login, before the normal landing page redirect.

**[loginUser](cci:1://file:///Users/orhangazibasli/Desktop/Paylasim/Project/sftpgo/internal/httpd/server.go:736:0-783:1)** — [internal/httpd/server.go](cci:7://file:///Users/orhangazibasli/Desktop/Paylasim/Project/sftpgo/internal/httpd/server.go:0:0-0:0)
```go
if user.MustChangePassword() {
    http.Redirect(w, r, webChangeClientPwdPath, http.StatusFound)
    return
}