### PR TITLE
feat: enable shared mode for sqlite

### DIFF
--- a/internal/dataprovider/dataprovider.go
+++ b/internal/dataprovider/dataprovider.go
@@ -203,7 +203,7 @@ var (
 	unixPwdPrefixes         = []string{md5cryptPwdPrefix, md5cryptApr1PwdPrefix, sha256cryptPwdPrefix, sha512cryptPwdPrefix,
 		yescryptPwdPrefix}
 	digestPwdPrefixes            = []string{md5DigestPwdPrefix, sha256DigestPwdPrefix, sha512DigestPwdPrefix}
-	sharedProviders              = []string{PGSQLDataProviderName, MySQLDataProviderName, CockroachDataProviderName}
+	sharedProviders              = []string{PGSQLDataProviderName, MySQLDataProviderName, CockroachDataProviderName, SQLiteDataProviderName}
 	logSender                    = "dataprovider"
 	sqlTableUsers                string
 	sqlTableFolders              string


### PR DESCRIPTION
SQLite3 has active-passive replication via litefs thus allowing us to use it in multi-instances of services. since table for share session already in the code of sqlite, why not enable it?


# Checklist for Pull Requests

- [ x] Have you signed the [Contributor License Agreement](https://sftpgo.com/cla.html)?

---
