### PR TITLE
webclient: hide preview button when user lacks download permission

### DIFF
--- a/internal/httpd/internal_test.go
+++ b/internal/httpd/internal_test.go
@@ -2168,6 +2168,49 @@ func TestRenderInvalidTemplate(t *testing.T) {
 	}
 }
 
+// TestFilesPageHidesViewerWithoutDownloadPermission is a regression test for
+// drakkan/sftpgo#2149. Users that lack PermDownload must not see the
+// eye/preview button in the WebClient file listing, since the underlying
+// editfile/preview endpoint can only return a permission error for them.
+func TestFilesPageHidesViewerWithoutDownloadPermission(t *testing.T) {
+	loadClientTemplates(filepath.Join("..", "..", "templates"))
+	tmpl, ok := clientTemplates[templateClientFiles]
+	require.True(t, ok, "files template must be loaded")
+	require.NotNil(t, tmpl)
+
+	render := func(canDownload bool) string {
+		data := filesPage{
+			baseClientPage: baseClientPage{
+				commonBasePage: commonBasePage{StaticURL: "/static"},
+				LoggedUser:     &dataprovider.User{},
+			},
+			CanDownload: canDownload,
+			QuotaUsage:  newUserQuotaUsage(&dataprovider.User{}),
+		}
+		var buf bytes.Buffer
+		require.NoError(t, tmpl.ExecuteTemplate(&buf, templateClientFiles, data))
+		return buf.String()
+	}
+
+	const (
+		// markers that only appear inside the preview-button switch block
+		imagePreviewMarker  = "data-iv-name="
+		editorPreviewMarker = "supportedEditExtensions.includes(extension)"
+	)
+
+	body := render(true)
+	assert.Contains(t, body, imagePreviewMarker,
+		"image preview button must render when user has download permission")
+	assert.Contains(t, body, editorPreviewMarker,
+		"text editor preview check must render when user has download permission")
+
+	body = render(false)
+	assert.NotContains(t, body, imagePreviewMarker,
+		"image preview button must be omitted when user lacks download permission")
+	assert.NotContains(t, body, editorPreviewMarker,
+		"text editor preview check must be omitted when user lacks download permission")
+}
+
 func TestQuotaScanInvalidFs(t *testing.T) {
 	user := &dataprovider.User{
 		BaseUser: sdk.BaseUser{

--- a/templates/webclient/files.html
+++ b/templates/webclient/files.html
@@ -677,6 +677,7 @@ explicit grant from the SFTPGo Team (support@sftpgo.com).
                             if (type === 'display') {
                                 let previewDiv = "";
                                 if (row["type"] == "2") {
+                                    //{{- if .CanDownload}}
                                     let filename = escapeHTML(row["name"]);
                                     let extension = filename.slice((filename.lastIndexOf(".") - 1 >>> 0) + 2).toLowerCase();
                                     switch (extension) {
@@ -745,6 +746,7 @@ explicit grant from the SFTPGo Team (support@sftpgo.com).
                                             }
                                             //{{- end}}
                                     }
+                                    //{{- end}}
                                 }
                                 let more = `{{- if not .ShareUploadBaseURL}}
                                             {{- if or .CanRename .CanAddFiles .CanShare .CanDelete }}


### PR DESCRIPTION
## Summary

Fixes #2149.

The eye/preview button in the WebClient file listing rendered for every supported preview extension (image / audio-video / PDF / text-editor) regardless of whether the user had `PermDownload` for the directory. Clicking it always hit the editfile/preview endpoint, which then errored out with `Cannot open file editor: You do not have the required permissions`.

This produced:
- Confusing UX (an action that looked clickable was never going to succeed).
- Spurious "security finding" reports during pen testing, since the UI was advertising an action the server would always reject.

## Change

`templates/webclient/files.html`: wrap the preview-button switch (lines ~680–747) in a `{{- if .CanDownload}} ... {{- end}}` block, matching the existing `//{{- if not .ShareUploadBaseURL}}` convention used a few lines below. `filesPage.CanDownload` is already populated correctly on both code paths (`renderFilesPage` for the regular view, `renderSharedFilesPage` for shares), so no Go-side wiring was required.

The server-side authorization in `handleClientEditFile` / `getFileReader` is unchanged — this PR is purely a UI fix; it does not change what the server allows.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] New unit test `TestFilesPageHidesViewerWithoutDownloadPermission` in `internal/httpd/internal_test.go` renders the `files.html` template with `CanDownload: true` and `CanDownload: false` and asserts the preview-button markers (`data-iv-name=` for the image case, `supportedEditExtensions.includes(extension)` for the editor case) are present in the first and absent in the second.
- [x] Existing `TestRenderInvalidTemplate`, `TestRenderUnexistingFolder`, and the `TestStaticFiles*`/`TestWebClient*`/`TestWebUserShare*` test families still pass.
- [x] Manually verified the conditional removes the eye icon from the listing for a user without download permission.

## Out of scope

- Not changing the `edit_url` field on the directory-listing JSON (`internal/httpd/webclient.go:1269`). The server-side check is the source of truth; hiding the button is sufficient for the UX bug.
- Not retitling/refactoring "viewer" vs "preview" vs "editor" naming.