### PR TITLE
dataprovider: surface bcrypt 72-byte limit as a typed validation error

### DIFF
--- a/internal/dataprovider/admin.go
+++ b/internal/dataprovider/admin.go
@@ -281,7 +281,7 @@ func (a *Admin) hashPassword() error {
 		if config.PasswordHashing.Algo == HashingAlgoBcrypt {
 			pwd, err := bcrypt.GenerateFromPassword([]byte(a.Password), config.PasswordHashing.BcryptOptions.Cost)
 			if err != nil {
-				return err
+				return wrapBcryptError(err)
 			}
 			a.Password = util.BytesToString(pwd)
 		} else {

--- a/internal/dataprovider/apikey.go
+++ b/internal/dataprovider/apikey.go
@@ -116,7 +116,7 @@ func (k *APIKey) hashKey() error {
 		if config.PasswordHashing.Algo == HashingAlgoBcrypt {
 			hashed, err := bcrypt.GenerateFromPassword([]byte(k.Key), config.PasswordHashing.BcryptOptions.Cost)
 			if err != nil {
-				return err
+				return wrapBcryptError(err)
 			}
 			k.Key = util.BytesToString(hashed)
 		} else {

--- a/internal/dataprovider/dataprovider.go
+++ b/internal/dataprovider/dataprovider.go
@@ -3332,10 +3332,26 @@ func validateBaseParams(user *User) error {
 	return nil
 }
 
+// wrapBcryptError translates bcrypt.ErrPasswordTooLong into a typed
+// validation error with an i18n key so callers map it to a localized
+// 400 response instead of a generic 500. Other errors are returned as-is.
+func wrapBcryptError(err error) error {
+	if errors.Is(err, bcrypt.ErrPasswordTooLong) {
+		return util.NewI18nError(
+			util.NewValidationError("the provided password is too long, the maximum is 72 bytes"),
+			util.I18nErrorPasswordTooLong,
+		)
+	}
+	return err
+}
+
 func hashPlainPassword(plainPwd string) (string, error) {
 	if config.PasswordHashing.Algo == HashingAlgoBcrypt {
 		pwd, err := bcrypt.GenerateFromPassword([]byte(plainPwd), config.PasswordHashing.BcryptOptions.Cost)
 		if err != nil {
+			if errors.Is(err, bcrypt.ErrPasswordTooLong) {
+				return "", wrapBcryptError(err)
+			}
 			return "", fmt.Errorf("bcrypt hashing error: %w", err)
 		}
 		return util.BytesToString(pwd), nil

--- a/internal/dataprovider/share.go
+++ b/internal/dataprovider/share.go
@@ -158,7 +158,7 @@ func (s *Share) hashPassword() error {
 		if config.PasswordHashing.Algo == HashingAlgoBcrypt {
 			hashed, err := bcrypt.GenerateFromPassword([]byte(s.Password), config.PasswordHashing.BcryptOptions.Cost)
 			if err != nil {
-				return err
+				return wrapBcryptError(err)
 			}
 			s.Password = util.BytesToString(hashed)
 		} else {

--- a/internal/httpd/httpd_test.go
+++ b/internal/httpd/httpd_test.go
@@ -9775,6 +9775,24 @@ func TestAddAdminNoPasswordMock(t *testing.T) {
 	assert.Contains(t, rr.Body.String(), "please set a password")
 }
 
+// TestAddAdminPasswordTooLongMock is a regression test for drakkan/sftpgo#2171.
+// Submitting a password longer than bcrypt's 72-byte limit must surface as a
+// 400 with a clear "too long" message, not the generic 500.
+func TestAddAdminPasswordTooLongMock(t *testing.T) {
+	token, err := getJWTAPITokenFromTestServer(defaultTokenAuthUser, defaultTokenAuthPass)
+	assert.NoError(t, err)
+	admin := getTestAdmin()
+	admin.Username = "admin_too_long_pwd"
+	admin.Password = strings.Repeat("a", 73)
+	asJSON, err := json.Marshal(admin)
+	assert.NoError(t, err)
+	req, _ := http.NewRequest(http.MethodPost, adminPath, bytes.NewBuffer(asJSON))
+	setBearerForReq(req, token)
+	rr := executeRequest(req)
+	checkResponseCode(t, http.StatusBadRequest, rr)
+	assert.Contains(t, rr.Body.String(), "too long")
+}
+
 func TestAdminTwoFactorLogin(t *testing.T) {
 	admin := getTestAdmin()
 	admin.Username = altAdminUsername

--- a/internal/util/i18n.go
+++ b/internal/util/i18n.go
@@ -138,6 +138,7 @@ const (
 	I18nErrorFolderQuotaFileInvalid    = "user.folder_quota_file_invalid"
 	I18nErrorFolderQuotaInvalid        = "user.folder_quota_invalid"
 	I18nErrorPasswordComplexity        = "general.err_password_complexity"
+	I18nErrorPasswordTooLong           = "general.err_password_too_long"
 	I18nErrorIPFiltersInvalid          = "user.ip_filters_invalid"
 	I18nErrorSourceBWLimitInvalid      = "user.src_bw_limits_invalid"
 	I18nErrorShareExpirationInvalid    = "user.share_expiration_invalid"

--- a/static/locales/en/translation.json
+++ b/static/locales/en/translation.json
@@ -188,6 +188,7 @@
         "ip_forbidden": "Login not allowed from this IP address",
         "email_invalid": "The email address is invalid",
         "err_password_complexity": "The password provided does not meet the complexity requirements",
+        "err_password_too_long": "The provided password is too long. The maximum length is 72 bytes.",
         "no_oidc_feature": "This feature is not available if you are logged in with OpenID",
         "connection_forbidden": "You are not allowed to connect",
         "no_permissions": "You are not allowed to change anything",


### PR DESCRIPTION
## Summary

Fixes #2171.

When a password longer than bcrypt's 72-byte limit was submitted, the bare `bcrypt.ErrPasswordTooLong` ("bcrypt: password length exceeds 72 bytes") propagated up unwrapped:

- **WebAdmin / WebClient**: `getRespStatus` falls through to `http.StatusInternalServerError` because the error isn't a `*ValidationError`. The user sees the generic "The server is unable to fulfill your request" warning, with no hint that password length is the problem.
- **CLI** (`sftpgo resetpwd --admin`): the implementation-level bcrypt message is printed verbatim.

## Change

Add a small `wrapBcryptError` helper in `internal/dataprovider/dataprovider.go` that translates `bcrypt.ErrPasswordTooLong` into `util.NewI18nError(util.NewValidationError(...), util.I18nErrorPasswordTooLong)`. Wire it into the four bcrypt call sites (`Admin.hashPassword`, `hashPlainPassword`, `Share.hashPassword`, `APIKey.hashKey`). Add the matching `general.err_password_too_long` i18n key + EN translation.

`argon2id` setups are unaffected — there is no 72-byte limit on that path. Other bcrypt errors (e.g., cost-related failures) flow through unchanged.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] New `TestAddAdminPasswordTooLongMock` in `internal/httpd/httpd_test.go` posts an admin with a 73-byte password, expects HTTP 400, and asserts the response body contains "too long".
- [x] Existing `TestAddAdminNoPasswordMock`, `TestAddAdmin`, `TestUserPassword`, `TestSharePassword`, `TestChangeAdminPassword`, `TestUserPasswordHashing` all pass.
- [x] Manually verified: hitting the WebAdmin "Add Admin" form with a 100-character password now shows the friendly length message instead of "Unable to fulfill your request".

## Out of scope

- Pre-hashing long passwords with SHA-256 before bcrypt (would change the security model).
- Translating the new key into ZH/ES/FR/IT/DE — those go through Crowdin per the project's i18n workflow.

## Diff stats

7 files changed, 39 insertions, 3 deletions.