### PR TITLE
fix: compare duplicate slice values correctly

### DIFF
--- a/internal/util/util.go
+++ b/internal/util/util.go
@@ -44,7 +44,6 @@ import (
 	"path/filepath"
 	"regexp"
 	"runtime"
-	"slices"
 	"strconv"
 	"strings"
 	"time"
@@ -978,10 +977,15 @@ func SlicesEqual(s1, s2 []string) bool {
 	if len(s1) != len(s2) {
 		return false
 	}
+	counts := make(map[string]int, len(s1))
 	for _, v := range s1 {
-		if !slices.Contains(s2, v) {
+		counts[v]++
+	}
+	for _, v := range s2 {
+		if counts[v] == 0 {
 			return false
 		}
+		counts[v]--
 	}
 
 	return true

--- a/internal/util/util_test.go
+++ b/internal/util/util_test.go
@@ -1,0 +1,71 @@
+// Copyright (C) 2019 Nicola Murino
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published
+// by the Free Software Foundation, version 3.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+package util
+
+import "testing"
+
+func TestSlicesEqual(t *testing.T) {
+	tests := []struct {
+		name string
+		s1   []string
+		s2   []string
+		want bool
+	}{
+		{
+			name: "same order",
+			s1:   []string{"read", "write"},
+			s2:   []string{"read", "write"},
+			want: true,
+		},
+		{
+			name: "different order",
+			s1:   []string{"read", "write"},
+			s2:   []string{"write", "read"},
+			want: true,
+		},
+		{
+			name: "different lengths",
+			s1:   []string{"read"},
+			s2:   []string{"read", "write"},
+			want: false,
+		},
+		{
+			name: "same length different values",
+			s1:   []string{"read", "write"},
+			s2:   []string{"read", "delete"},
+			want: false,
+		},
+		{
+			name: "same length different multiplicity",
+			s1:   []string{"read", "write"},
+			s2:   []string{"read", "read"},
+			want: false,
+		},
+		{
+			name: "same multiplicity",
+			s1:   []string{"read", "read", "write"},
+			s2:   []string{"write", "read", "read"},
+			want: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := SlicesEqual(tt.s1, tt.s2); got != tt.want {
+				t.Fatalf("SlicesEqual(%v, %v) = %v, want %v", tt.s1, tt.s2, got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## What
`util.SlicesEqual` now checks duplicate counts, not only membership.

Small footgun, but it can matter for admin self-permission checks.

## Repro
Before this patch:

`SlicesEqual([]string{"read", "write"}, []string{"read", "read"}) == true`

same length, different values, still true. not it tbh.

## Tests
`go test ./internal/util -count=1`

`go test -tags nopgxregisterdefaulttypes,disable_grpc_modules -p 1 -timeout 5m ./internal/httpd -run 'TestAdminUpdateSelf|TestAdminUpdateSelfMock' -count=1`

## Checklist
- [x] Have you signed the [Contributor License Agreement](https://sftpgo.com/cla.html)?