### PR TITLE
[2.5.x] Review token invalidation after password change for CVE-2024-37897

### DIFF
--- a/internal/httpd/api_admin.go
+++ b/internal/httpd/api_admin.go
@@ -284,6 +284,7 @@ func changeAdminPassword(w http.ResponseWriter, r *http.Request) {
 		sendAPIResponse(w, r, err, "", getRespStatus(err))
 		return
 	}
+	invalidateToken(r)
 	sendAPIResponse(w, r, err, "Password updated", http.StatusOK)
 }
 

--- a/internal/httpd/api_http_user.go
+++ b/internal/httpd/api_http_user.go
@@ -527,6 +527,7 @@ func changeUserPassword(w http.ResponseWriter, r *http.Request) {
 		sendAPIResponse(w, r, err, "", getRespStatus(err))
 		return
 	}
+	invalidateToken(r)
 	sendAPIResponse(w, r, err, "Password updated", http.StatusOK)
 }
 

--- a/internal/httpd/httpd.go
+++ b/internal/httpd/httpd.go
@@ -674,6 +674,10 @@ func (b *Binding) showClientLoginURL() bool {
 	return true
 }
 
+func (b *Binding) isMutualTLSEnabled() bool {
+	return b.ClientAuthType == 1
+}
+
 type defenderStatus struct {
 	IsActive bool `json:"is_active"`
 }

--- a/internal/httpd/httpd_test.go
+++ b/internal/httpd/httpd_test.go
@@ -10935,11 +10935,17 @@ func TestWebAPIChangeUserPwdMock(t *testing.T) {
 	assert.NoError(t, err)
 	token, err := getJWTAPIUserTokenFromTestServer(defaultUsername, defaultPassword)
 	assert.NoError(t, err)
-	// invalid json
-	req, err := http.NewRequest(http.MethodPut, userPwdPath, bytes.NewBuffer([]byte("{")))
+
+	req, err := http.NewRequest(http.MethodGet, userProfilePath, nil)
 	assert.NoError(t, err)
 	setBearerForReq(req, token)
 	rr := executeRequest(req)
+	checkResponseCode(t, http.StatusOK, rr)
+	// invalid json
+	req, err = http.NewRequest(http.MethodPut, userPwdPath, bytes.NewBuffer([]byte("{")))
+	assert.NoError(t, err)
+	setBearerForReq(req, token)
+	rr = executeRequest(req)
 	checkResponseCode(t, http.StatusBadRequest, rr)
 
 	pwd := make(map[string]string)
@@ -10962,6 +10968,13 @@ func TestWebAPIChangeUserPwdMock(t *testing.T) {
 	setBearerForReq(req, token)
 	rr = executeRequest(req)
 	checkResponseCode(t, http.StatusOK, rr)
+
+	req, err = http.NewRequest(http.MethodGet, userProfilePath, nil)
+	assert.NoError(t, err)
+	setBearerForReq(req, token)
+	rr = executeRequest(req)
+	checkResponseCode(t, http.StatusUnauthorized, rr)
+
 	_, err = getJWTAPIUserTokenFromTestServer(defaultUsername, defaultPassword)
 	assert.Error(t, err)
 	token, err = getJWTAPIUserTokenFromTestServer(defaultUsername, altAdminPassword)
@@ -11111,6 +11124,12 @@ func TestChangeAdminPwdMock(t *testing.T) {
 	setBearerForReq(req, altToken)
 	rr = executeRequest(req)
 	checkResponseCode(t, http.StatusOK, rr)
+	// try using the old token
+	req, err = http.NewRequest(http.MethodGet, versionPath, nil)
+	assert.NoError(t, err)
+	setBearerForReq(req, altToken)
+	rr = executeRequest(req)
+	checkResponseCode(t, http.StatusUnauthorized, rr)
 
 	_, err = getJWTAPITokenFromTestServer(altAdminUsername, altAdminPassword)
 	assert.Error(t, err)
@@ -13126,6 +13145,13 @@ func TestWebClientChangePwd(t *testing.T) {
 	rr = executeRequest(req)
 	checkResponseCode(t, http.StatusFound, rr)
 	assert.Equal(t, webClientLoginPath, rr.Header().Get("Location"))
+
+	req, err = http.NewRequest(http.MethodGet, webClientPingPath, nil)
+	assert.NoError(t, err)
+	req.RemoteAddr = defaultRemoteAddr
+	setJWTCookieForReq(req, webToken)
+	rr = executeRequest(req)
+	checkResponseCode(t, http.StatusFound, rr)
 
 	_, err = getJWTWebClientTokenFromTestServer(defaultUsername, defaultPassword)
 	assert.Error(t, err)
@@ -17548,6 +17574,12 @@ func TestWebAdminLoginMock(t *testing.T) {
 	checkResponseCode(t, http.StatusFound, rr)
 	cookie := rr.Header().Get("Cookie")
 	assert.Empty(t, cookie)
+
+	req, _ = http.NewRequest(http.MethodGet, webStatusPath, nil)
+	req.RemoteAddr = defaultRemoteAddr
+	setJWTCookieForReq(req, webToken)
+	rr = executeRequest(req)
+	checkResponseCode(t, http.StatusFound, rr)
 
 	req, _ = http.NewRequest(http.MethodGet, logoutPath, nil)
 	setBearerForReq(req, apiToken)

--- a/internal/httpd/server.go
+++ b/internal/httpd/server.go
@@ -117,7 +117,7 @@ func (s *httpdServer) listenAndServe() error {
 		httpServer.TLSConfig = config
 		logger.Debug(logSender, "", "configured TLS cipher suites for binding %q: %v, certID: %v",
 			s.binding.GetAddress(), httpServer.TLSConfig.CipherSuites, certID)
-		if s.binding.ClientAuthType == 1 {
+		if s.binding.isMutualTLSEnabled() {
 			httpServer.TLSConfig.ClientCAs = certMgr.GetRootCAs()
 			httpServer.TLSConfig.ClientAuth = tls.RequireAndVerifyClientCert
 			httpServer.TLSConfig.VerifyConnection = s.verifyTLSConnection


### PR DESCRIPTION
Backport of the public CVE-2024-37897 fix to `2.5.x`.

I cherry-picked `1f8ac8bfe161` from upstream with `git cherry-pick -x`, so the original author and upstream commit reference are preserved. The source change touches the REST password-change handlers and HTTP server helper code.

Upstream commit: https://github.com/drakkan/sftpgo/commit/1f8ac8bfe16100b0484d6c91e1e8361687324423
CVE reference: https://nvd.nist.gov/vuln/detail/CVE-2024-37897

Cherry-pick conflicted only in `go.mod` and `go.sum`. I kept the target branch dependency files and carried the source changes that invalidate existing tokens after password changes. I could not run the local Go test suite in this environment because the `go` command is not installed.