### PR TITLE
Harden local filesystem writes against symlink escape

### DIFF
--- a/internal/vfs/osfs.go
+++ b/internal/vfs/osfs.go
@@ -134,6 +134,11 @@ func (fs *OsFs) Open(name string, offset int64) (File, PipeReader, func(), error
 
 // Create creates or opens the named file for writing
 func (fs *OsFs) Create(name string, flag, _ int) (File, PipeWriter, func(), error) {
+	if !fs.isAtomicUploadTempPath(name) {
+		if err := fs.validateWriteTarget(name); err != nil {
+			return nil, nil, nil, err
+		}
+	}
 	if !fs.useWriteBuffering(flag) {
 		var err error
 		var f *os.File
@@ -178,6 +183,9 @@ func (fs *OsFs) Create(name string, flag, _ int) (File, PipeWriter, func(), erro
 func (fs *OsFs) Rename(source, target string, checks int) (int, int64, error) {
 	if source == target {
 		return -1, -1, nil
+	}
+	if err := fs.validateWriteTarget(target); err != nil {
+		return -1, -1, err
 	}
 	err := os.Rename(source, target)
 	if err != nil && isCrossDeviceError(err) {
@@ -346,6 +354,14 @@ func (*OsFs) GetAtomicUploadPath(name string) string {
 	}
 	guid := xid.New().String()
 	return filepath.Join(dir, ".sftpgo-upload."+guid+"."+filepath.Base(name))
+}
+
+func (*OsFs) isAtomicUploadTempPath(name string) bool {
+	if tempPath == "" {
+		return false
+	}
+	return filepath.Clean(filepath.Dir(name)) == filepath.Clean(tempPath) &&
+		strings.HasPrefix(filepath.Base(name), ".sftpgo-upload.")
 }
 
 // GetRelativePath returns the path for a file relative to the user's home dir.
@@ -532,6 +548,67 @@ func (fs *OsFs) findFirstExistingDir(path string) (string, error) {
 	}
 	err = fs.isSubDir(p)
 	return p, err
+}
+
+func (fs *OsFs) validateWriteTarget(name string) error {
+	cleanPath := filepath.Clean(name)
+	if err := fs.validateWritePath(filepath.Dir(cleanPath), 0); err != nil {
+		return err
+	}
+	info, err := os.Lstat(cleanPath)
+	if err == nil && info.Mode()&os.ModeSymlink != 0 {
+		return fs.validateLinkTarget(cleanPath, 0)
+	}
+	if err != nil && !fs.IsNotExist(err) {
+		return err
+	}
+	return nil
+}
+
+func (fs *OsFs) validateLinkTarget(name string, depth int) error {
+	target, err := os.Readlink(name)
+	if err != nil {
+		return err
+	}
+	if !filepath.IsAbs(target) {
+		target = filepath.Join(filepath.Dir(name), target)
+	}
+	return fs.validateWritePath(target, depth+1)
+}
+
+func (fs *OsFs) validateWritePath(name string, depth int) error {
+	if depth > 40 {
+		return fmt.Errorf("too many symlinks resolving %q", name)
+	}
+	cleanPath := filepath.Clean(name)
+	if p, err := filepath.EvalSymlinks(cleanPath); err == nil {
+		return fs.isSubDir(p)
+	} else if !fs.IsNotExist(err) {
+		return err
+	}
+
+	current := cleanPath
+	for {
+		info, err := os.Lstat(current)
+		if err == nil {
+			if info.Mode()&os.ModeSymlink != 0 {
+				return fs.validateLinkTarget(current, depth)
+			}
+			p, err := filepath.EvalSymlinks(current)
+			if err != nil {
+				return err
+			}
+			return fs.isSubDir(p)
+		}
+		if !fs.IsNotExist(err) {
+			return err
+		}
+		parent := filepath.Dir(current)
+		if parent == current {
+			return err
+		}
+		current = parent
+	}
 }
 
 func (fs *OsFs) isSubDir(sub string) error {

--- a/internal/vfs/osfs_test.go
+++ b/internal/vfs/osfs_test.go
@@ -1,0 +1,152 @@
+// Copyright (C) 2019 Nicola Murino
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published
+// by the Free Software Foundation, version 3.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+package vfs
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+)
+
+func newTestOsFs(t *testing.T) (*OsFs, string, string) {
+	t.Helper()
+
+	baseDir := t.TempDir()
+	rootDir := filepath.Join(baseDir, "root")
+	outsideDir := filepath.Join(baseDir, "outside")
+	if err := os.MkdirAll(filepath.Join(rootDir, "drop"), os.ModePerm); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(outsideDir, os.ModePerm); err != nil {
+		t.Fatal(err)
+	}
+
+	return NewOsFs("test", rootDir, "", nil).(*OsFs), rootDir, outsideDir
+}
+
+func TestOsFsCreateRejectsDanglingSymlinkOutsideRoot(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("symlink creation requires extra privileges on Windows")
+	}
+
+	fs, rootDir, outsideDir := newTestOsFs(t)
+	linkPath := filepath.Join(rootDir, "drop", "link")
+	outsideTarget := filepath.Join(outsideDir, "created.txt")
+	if err := os.Symlink("../../outside/created.txt", linkPath); err != nil {
+		t.Fatal(err)
+	}
+
+	f, w, cancelFn, err := fs.Create(linkPath, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0)
+	if err == nil {
+		if f != nil {
+			_ = f.Close()
+		}
+		if w != nil {
+			_ = w.Close()
+		}
+		if cancelFn != nil {
+			cancelFn()
+		}
+		t.Fatal("expected write through dangling symlink outside root to fail")
+	}
+	if _, statErr := os.Stat(outsideTarget); !errors.Is(statErr, os.ErrNotExist) {
+		t.Fatalf("outside target was created, stat err: %v", statErr)
+	}
+}
+
+func TestOsFsCreateAllowsDanglingSymlinkInsideRoot(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("symlink creation requires extra privileges on Windows")
+	}
+
+	fs, rootDir, _ := newTestOsFs(t)
+	linkPath := filepath.Join(rootDir, "drop", "link")
+	insideTarget := filepath.Join(rootDir, "created.txt")
+	if err := os.Symlink("../created.txt", linkPath); err != nil {
+		t.Fatal(err)
+	}
+
+	f, _, _, err := fs.Create(linkPath, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := f.Write([]byte("ok")); err != nil {
+		t.Fatal(err)
+	}
+	if err := f.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(insideTarget); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestOsFsCreateAllowsAtomicUploadTempPath(t *testing.T) {
+	fs, _, _ := newTestOsFs(t)
+	oldTempPath := tempPath
+	SetTempPath(t.TempDir())
+	t.Cleanup(func() {
+		SetTempPath(oldTempPath)
+	})
+
+	filePath := fs.GetAtomicUploadPath(filepath.Join(fs.rootDir, "file.txt"))
+	f, _, _, err := fs.Create(filePath, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := f.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(filePath); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestOsFsRenameRejectsSymlinkedParentOutsideRoot(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("symlink creation requires extra privileges on Windows")
+	}
+
+	fs, rootDir, outsideDir := newTestOsFs(t)
+	source := filepath.Join(filepath.Dir(rootDir), "upload.tmp")
+	outsideParent := filepath.Join(outsideDir, "parent")
+	if err := os.MkdirAll(outsideParent, os.ModePerm); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(source, []byte("payload"), os.ModePerm); err != nil {
+		t.Fatal(err)
+	}
+
+	targetParent := filepath.Join(rootDir, "drop")
+	if err := os.RemoveAll(targetParent); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink("../outside/parent", targetParent); err != nil {
+		t.Fatal(err)
+	}
+	target := filepath.Join(targetParent, "created.txt")
+
+	if _, _, err := fs.Rename(source, target, 0); err == nil {
+		t.Fatal("expected rename through symlinked parent outside root to fail")
+	}
+	if _, err := os.Stat(filepath.Join(outsideParent, "created.txt")); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("outside target was created, stat err: %v", err)
+	}
+	if _, err := os.Stat(source); err != nil {
+		t.Fatalf("source should remain after rejected rename: %v", err)
+	}
+}


### PR DESCRIPTION
## Summary

- validate local OS filesystem write targets before create and rename operations
- preserve configured atomic upload temp-file behavior while revalidating the final write target
- add regression tests for dangling symlink writes, safe in-root symlink writes, atomic temp files, and symlinked rename parents

## Security implication

On local filesystem backends, write and atomic-rename operations should not follow symlinks or stale parent paths outside the configured filesystem root. Without this extra validation, an authenticated user with file-write and symlink-capable permissions could write as the SFTPGo process user outside their authorized storage boundary. Depending on deployment permissions, that can allow modification of trusted files and may lead to code execution if a writable hook, plugin, config, service, template, or deployment path is targeted.

## CWEs

- CWE-59: Improper Link Resolution Before File Access
- CWE-22: Improper Limitation of a Pathname to a Restricted Directory
- CWE-73: External Control of File Name or Path
- CWE-367: Time-of-check Time-of-use Race Condition

## Tests

- `go test ./internal/vfs`
- `go test ./internal/sftpd -run 'Test(Link|EscapeHomeDir|ResolvePaths)$' -count=1`
