### PR TITLE
vfs: include the container when comparing Azure Blob resources

### DIFF
--- a/internal/common/common_test.go
+++ b/internal/common/common_test.go
@@ -1655,6 +1655,29 @@ func TestVfsSameResource(t *testing.T) {
 	res = fs.IsSameResource(other)
 	assert.False(t, res)
 	fs = vfs.Filesystem{
+		Provider: sdk.AzureBlobFilesystemProvider,
+		AzBlobConfig: vfs.AzBlobFsConfig{
+			BaseAzBlobFsConfig: sdk.BaseAzBlobFsConfig{
+				AccountName: "a",
+				Container:   "c1",
+			},
+		},
+	}
+	other = vfs.Filesystem{
+		Provider: sdk.AzureBlobFilesystemProvider,
+		AzBlobConfig: vfs.AzBlobFsConfig{
+			BaseAzBlobFsConfig: sdk.BaseAzBlobFsConfig{
+				AccountName: "a",
+				Container:   "c1",
+			},
+		},
+	}
+	res = fs.IsSameResource(other)
+	assert.True(t, res)
+	other.AzBlobConfig.Container = "c2"
+	res = fs.IsSameResource(other)
+	assert.False(t, res)
+	fs = vfs.Filesystem{
 		Provider: sdk.HTTPFilesystemProvider,
 		HTTPConfig: vfs.HTTPFsConfig{
 			BaseHTTPFsConfig: sdk.BaseHTTPFsConfig{

--- a/internal/vfs/vfs.go
+++ b/internal/vfs/vfs.go
@@ -818,6 +818,9 @@ func (c *AzBlobFsConfig) tryDecrypt() error {
 }
 
 func (c *AzBlobFsConfig) isSameResource(other AzBlobFsConfig) bool {
+	if c.Container != other.Container {
+		return false
+	}
 	if c.AccountName != other.AccountName {
 		return false
 	}


### PR DESCRIPTION
## Summary

`AzBlobFsConfig.isSameResource()` compares only account name, endpoint and SAS URL, ignoring the container. As a result two Azure Blob virtual folders that point at different containers in the same storage account are treated as the same resource.

This breaks copy/move between such folders:

- A copy that keeps the file name is rejected by `checkCopy` with `the copy source and target cannot be the same` (HTTP 400), because the container-relative paths are equal.
- A copy/move to a different name takes the `FsFileCopier` server-side fast path, where `copyFileInternal` builds both the source and destination block-blob clients from a single `containerClient` (the target's), so the source blob is looked up in the wrong container.

This PR adds a container comparison to `isSameResource`, mirroring `isEqual` and the bucket comparison used for the other object-storage providers. Different containers are now correctly reported as different resources, so cross-container copy/move falls back to the streaming (download + upload) path and succeeds; same-container operations keep the server-side fast path.

Fixes #2254

## Test

Extended `TestVfsSameResource` with an Azure Blob case covering same vs. different container.