### PR TITLE
api_maintenance: allow restore admin with no password

### DIFF
--- a/internal/httpd/api_maintenance.go
+++ b/internal/httpd/api_maintenance.go
@@ -419,6 +419,12 @@ func RestoreAdmins(admins []dataprovider.Admin, inputFile string, mode int, exec
 			err = dataprovider.UpdateAdmin(&admin, executor, ipAddress, role)
 			logger.Debug(logSender, "", "restoring existing admin %q, dump file: %q, error: %v", admin.Username, inputFile, err)
 		} else {
+			if admin.Password == "" {
+				// Administrators can be used with OpenID Connect or for authentication
+				// via API key, in these cases the password is not necessary, we create
+				// a non-usable one.
+				admin.Password = util.GenerateUniqueID()
+			}
 			err = dataprovider.AddAdmin(&admin, executor, ipAddress, role)
 			logger.Debug(logSender, "", "adding new admin %q, dump file: %q, error: %v", admin.Username, inputFile, err)
 		}


### PR DESCRIPTION
# Checklist for Pull Requests

- [x] Have you signed the [Contributor License Agreement](https://sftpgo.com/cla.html)?

---

https://github.com/drakkan/sftpgo/commit/70f8b4d49510d9e4a67ad62657da02cb519e7998
allows creating an admin with unusable password for OpenID.

This is to allow LoadData and Maintenance Backup Restore accepts empty admin password 
