### PR TITLE
Query OIDC's UserInfo endpoint for authorotative claims

### DIFF
--- a/internal/httpd/httpd_test.go
+++ b/internal/httpd/httpd_test.go
@@ -27681,6 +27681,10 @@ func startOIDCMockServer() {
 			w.WriteHeader(http.StatusNotFound)
 			fmt.Fprintf(w, "Not found\n")
 		})
+		// tests that don't set a UserInfo mock fall back to id-token claims deterministically
+		http.HandleFunc("/auth/realms/sftpgo/protocol/openid-connect/userinfo", func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusUnauthorized)
+		})
 		if err := http.ListenAndServe(oidcMockAddr, nil); err != nil {
 			logger.ErrorToConsole("could not start HTTP notification server: %v", err)
 			os.Exit(1)

--- a/internal/httpd/httpd_test.go
+++ b/internal/httpd/httpd_test.go
@@ -27681,10 +27681,6 @@ func startOIDCMockServer() {
 			w.WriteHeader(http.StatusNotFound)
 			fmt.Fprintf(w, "Not found\n")
 		})
-		// tests that don't set a UserInfo mock fall back to id-token claims deterministically
-		http.HandleFunc("/auth/realms/sftpgo/protocol/openid-connect/userinfo", func(w http.ResponseWriter, _ *http.Request) {
-			w.WriteHeader(http.StatusUnauthorized)
-		})
 		if err := http.ListenAndServe(oidcMockAddr, nil); err != nil {
 			logger.ErrorToConsole("could not start HTTP notification server: %v", err)
 			os.Exit(1)

--- a/internal/httpd/oidc.go
+++ b/internal/httpd/oidc.go
@@ -63,6 +63,12 @@ type OIDCTokenVerifier interface {
 	Verify(ctx context.Context, rawIDToken string) (*oidc.IDToken, error)
 }
 
+// OIDCUserInfoFetcher defines an interface for querying the OpenID UserInfo
+// endpoint, so we can mock it in tests. *oidc.Provider satisfies it.
+type OIDCUserInfoFetcher interface {
+	UserInfo(ctx context.Context, tokenSource oauth2.TokenSource) (*oidc.UserInfo, error)
+}
+
 // OIDC defines the OpenID Connect configuration
 type OIDC struct {
 	// ClientID is the application's ID
@@ -95,6 +101,9 @@ type OIDC struct {
 	Scopes []string `json:"scopes" mapstructure:"scopes"`
 	// Custom token claims fields to pass to the pre-login hook
 	CustomFields []string `json:"custom_fields" mapstructure:"custom_fields"`
+	// If set, claims are read only from the verified ID token and the UserInfo
+	// endpoint is not queried. Only needed for providers that fail to support UserInfo.
+	IDTokenClaimsOnly bool `json:"id_token_claims_only" mapstructure:"id_token_claims_only"`
 	// InsecureSkipSignatureCheck causes SFTPGo to skip JWT signature validation.
 	// It's intended for special cases where providers, such as Azure, use the "none"
 	// algorithm. Skipping the signature validation can cause security issues
@@ -104,6 +113,7 @@ type OIDC struct {
 	Debug             bool `json:"debug" mapstructure:"debug"`
 	provider          *oidc.Provider
 	verifier          OIDCTokenVerifier
+	userInfoFetcher   OIDCUserInfoFetcher
 	providerLogoutURL string
 	oauth2Config      OAuth2Config
 }
@@ -174,6 +184,7 @@ func (o *OIDC) initialize() error {
 	}
 	o.provider = provider
 	o.verifier = nil
+	o.userInfoFetcher = nil
 	o.oauth2Config = &oauth2.Config{
 		ClientID:     o.ClientID,
 		ClientSecret: o.ClientSecret,
@@ -193,6 +204,48 @@ func (o *OIDC) getVerifier(ctx context.Context) OIDCTokenVerifier {
 		ClientID:                   o.ClientID,
 		InsecureSkipSignatureCheck: o.InsecureSkipSignatureCheck,
 	})
+}
+
+func (o *OIDC) getUserInfoFetcher() OIDCUserInfoFetcher {
+	if o.userInfoFetcher != nil {
+		return o.userInfoFetcher
+	}
+	return o.provider
+}
+
+// resolveClaims returns the claims map used to derive the SFTPGo identity. An
+// unreachable UserInfo endpoint is an availability failure and falls back to the
+// id token claims; a UserInfo response that is reached but cannot be trusted (its
+// subject differs from the id token subject, or its body cannot be parsed) is an
+// integrity failure and rejects the login.
+func (o *OIDC) resolveClaims(ctx context.Context, idToken *oidc.IDToken,
+	idTokenClaims map[string]any, accessToken *oauth2.Token,
+) (map[string]any, error) {
+	if o.IDTokenClaimsOnly {
+		return idTokenClaims, nil
+	}
+	if accessToken == nil || accessToken.AccessToken == "" {
+		logger.Warn(logSender, "", "no access token available to query the OpenID UserInfo endpoint, using id token claims")
+		return idTokenClaims, nil
+	}
+	ctx, cancel := context.WithTimeout(ctx, 15*time.Second)
+	defer cancel()
+	userInfo, err := o.getUserInfoFetcher().UserInfo(ctx, oauth2.StaticTokenSource(accessToken))
+	if err != nil {
+		logger.Warn(logSender, "", "unable to query the OpenID UserInfo endpoint, falling back to id token claims: %v", err)
+		return idTokenClaims, nil
+	}
+	if userInfo.Subject != idToken.Subject {
+		logger.Warn(logSender, "", "OpenID UserInfo subject %q does not match id token subject %q",
+			userInfo.Subject, idToken.Subject)
+		return nil, errors.New("UserInfo subject does not match id token subject")
+	}
+	userInfoClaims := make(map[string]any)
+	if err := userInfo.Claims(&userInfoClaims); err != nil {
+		logger.Warn(logSender, "", "unable to parse OpenID UserInfo claims: %v", err)
+		return nil, fmt.Errorf("unable to parse OpenID UserInfo claims: %w", err)
+	}
+	return mergeOIDCClaims(idTokenClaims, userInfoClaims), nil
 }
 
 type oidcPendingAuth struct {
@@ -709,6 +762,14 @@ func (s *httpdServer) handleOIDCRedirect(w http.ResponseWriter, r *http.Request)
 		doLogout(rawIDToken)
 		return
 	}
+	claims, err = s.binding.OIDC.resolveClaims(ctx, idToken, claims, oauth2Token)
+	if err != nil {
+		logger.Debug(logSender, "", "unable to resolve oidc claims: %v", err)
+		setFlashMessage(w, r, newFlashMessage("Unable to verify OpenID claims", util.I18nOIDCTokenInvalid))
+		doRedirect()
+		doLogout(rawIDToken)
+		return
+	}
 	s.debugTokenClaims(claims, rawIDToken)
 	token := oidcToken{
 		AccessToken:  oauth2Token.AccessToken,
@@ -892,4 +953,24 @@ func getOIDCFieldFromClaims(claims map[string]any, fieldName string) (any, bool)
 	}
 
 	return val, ok
+}
+
+// mergeOIDCClaims overlays UserInfo claims over ID token claims (UserInfo wins on
+// conflict, token-only claims are preserved). The "sid" session claim is kept from
+// the ID token: it belongs to the id/logout token per the Back-Channel Logout spec,
+// and a stray UserInfo "sid" must not desync back-channel logout.
+func mergeOIDCClaims(idTokenClaims, userInfoClaims map[string]any) map[string]any {
+	merged := make(map[string]any, len(idTokenClaims)+len(userInfoClaims))
+	for k, v := range idTokenClaims {
+		merged[k] = v
+	}
+	for k, v := range userInfoClaims {
+		if k == "sid" {
+			if _, ok := idTokenClaims["sid"]; ok {
+				continue
+			}
+		}
+		merged[k] = v
+	}
+	return merged
 }

--- a/internal/httpd/oidc.go
+++ b/internal/httpd/oidc.go
@@ -67,6 +67,8 @@ type OIDCTokenVerifier interface {
 // endpoint, so we can mock it in tests. *oidc.Provider satisfies it.
 type OIDCUserInfoFetcher interface {
 	UserInfo(ctx context.Context, tokenSource oauth2.TokenSource) (*oidc.UserInfo, error)
+	// UserInfoEndpoint returns the discovered userinfo_endpoint, or "" if unadvertised.
+	UserInfoEndpoint() string
 }
 
 // OIDC defines the OpenID Connect configuration
@@ -102,7 +104,8 @@ type OIDC struct {
 	// Custom token claims fields to pass to the pre-login hook
 	CustomFields []string `json:"custom_fields" mapstructure:"custom_fields"`
 	// If set, claims are read only from the verified ID token and the UserInfo
-	// endpoint is not queried. Only needed for providers that fail to support UserInfo.
+	// endpoint is never queried, even when advertised. An unadvertised endpoint is
+	// skipped automatically, so this is only for overriding a broken advertised one.
 	IDTokenClaimsOnly bool `json:"id_token_claims_only" mapstructure:"id_token_claims_only"`
 	// InsecureSkipSignatureCheck causes SFTPGo to skip JWT signature validation.
 	// It's intended for special cases where providers, such as Azure, use the "none"
@@ -214,26 +217,29 @@ func (o *OIDC) getUserInfoFetcher() OIDCUserInfoFetcher {
 }
 
 // resolveClaims returns the claims map used to derive the SFTPGo identity. An
-// unreachable UserInfo endpoint is an availability failure and falls back to the
-// id token claims; a UserInfo response that is reached but cannot be trusted (its
-// subject differs from the id token subject, or its body cannot be parsed) is an
-// integrity failure and rejects the login.
+// unadvertised UserInfo endpoint falls back to the id token claims; once the
+// endpoint is advertised the login is rejected unless it can be queried and trusted
+// (its subject must match the id token subject and its body must parse).
 func (o *OIDC) resolveClaims(ctx context.Context, idToken *oidc.IDToken,
 	idTokenClaims map[string]any, accessToken *oauth2.Token,
 ) (map[string]any, error) {
 	if o.IDTokenClaimsOnly {
 		return idTokenClaims, nil
 	}
-	if accessToken == nil || accessToken.AccessToken == "" {
-		logger.Warn(logSender, "", "no access token available to query the OpenID UserInfo endpoint, using id token claims")
+	fetcher := o.getUserInfoFetcher()
+	if fetcher.UserInfoEndpoint() == "" {
 		return idTokenClaims, nil
+	}
+	if accessToken == nil || accessToken.AccessToken == "" {
+		logger.Warn(logSender, "", "no access token available to query the advertised OpenID UserInfo endpoint")
+		return nil, errors.New("no access token available to query the UserInfo endpoint")
 	}
 	ctx, cancel := context.WithTimeout(ctx, 15*time.Second)
 	defer cancel()
-	userInfo, err := o.getUserInfoFetcher().UserInfo(ctx, oauth2.StaticTokenSource(accessToken))
+	userInfo, err := fetcher.UserInfo(ctx, oauth2.StaticTokenSource(accessToken))
 	if err != nil {
-		logger.Warn(logSender, "", "unable to query the OpenID UserInfo endpoint, falling back to id token claims: %v", err)
-		return idTokenClaims, nil
+		logger.Warn(logSender, "", "unable to query the advertised OpenID UserInfo endpoint: %v", err)
+		return nil, fmt.Errorf("unable to query the UserInfo endpoint: %w", err)
 	}
 	if userInfo.Subject != idToken.Subject {
 		logger.Warn(logSender, "", "OpenID UserInfo subject %q does not match id token subject %q",

--- a/internal/httpd/oidc_test.go
+++ b/internal/httpd/oidc_test.go
@@ -89,12 +89,22 @@ func (v *mockOIDCVerifier) Verify(_ context.Context, _ string) (*oidc.IDToken, e
 }
 
 type mockOIDCUserInfoFetcher struct {
-	userInfo *oidc.UserInfo
-	err      error
+	userInfo   *oidc.UserInfo
+	err        error
+	noEndpoint bool
 }
 
 func (f *mockOIDCUserInfoFetcher) UserInfo(_ context.Context, _ oauth2.TokenSource) (*oidc.UserInfo, error) {
 	return f.userInfo, f.err
+}
+
+// UserInfoEndpoint is non-empty by default so mocks exercise the query path; set
+// noEndpoint to model a provider that does not advertise one.
+func (f *mockOIDCUserInfoFetcher) UserInfoEndpoint() string {
+	if f.noEndpoint {
+		return ""
+	}
+	return "https://example.test/userinfo"
 }
 
 // setClaims writes the raw claims payload into the unexported "claims" field that
@@ -102,6 +112,21 @@ func (f *mockOIDCUserInfoFetcher) UserInfo(_ context.Context, _ oauth2.TokenSour
 func setClaims(v any, claims []byte) {
 	member := reflect.Indirect(reflect.ValueOf(v)).FieldByName("claims")
 	*(*[]byte)(unsafe.Pointer(member.UnsafeAddr())) = claims
+}
+
+// echoUserInfoFetcher models a spec-compliant provider whose UserInfo agrees with
+// the id token: it returns the current verifier token's subject and raw claims, so
+// the mandatory merge is a faithful identity for tests exercising the login flow.
+type echoUserInfoFetcher struct{ oidc *OIDC }
+
+func (f *echoUserInfoFetcher) UserInfoEndpoint() string { return "https://example.test/userinfo" }
+
+func (f *echoUserInfoFetcher) UserInfo(_ context.Context, _ oauth2.TokenSource) (*oidc.UserInfo, error) {
+	idToken := f.oidc.verifier.(*mockOIDCVerifier).token
+	ui := &oidc.UserInfo{Subject: idToken.Subject}
+	member := reflect.Indirect(reflect.ValueOf(idToken)).FieldByName("claims")
+	setClaims(ui, *(*[]byte)(unsafe.Pointer(member.UnsafeAddr())))
+	return ui, nil
 }
 
 func setUserInfoClaims(ui *oidc.UserInfo, claims []byte) { setClaims(ui, claims) }
@@ -196,12 +221,12 @@ func TestOIDCRedirectSubMismatchRejected(t *testing.T) {
 	assert.Equal(t, webClientLoginPath, rr.Header().Get("Location"))
 }
 
-func TestOIDCRedirectUserInfoErrorFallsBack(t *testing.T) {
+func TestOIDCRedirectUserInfoErrorRejected(t *testing.T) {
 	rr := oidcRedirectHarness(t, "test_oidc_ui_user",
 		`{"sub":"user-sub","preferred_username":"test_oidc_ui_user"}`,
 		nil, fmt.Errorf("userinfo unreachable"), false)
 	assert.Equal(t, http.StatusFound, rr.Code, rr.Body.String())
-	assert.Equal(t, webClientFilesPath, rr.Header().Get("Location"))
+	assert.Equal(t, webClientLoginPath, rr.Header().Get("Location"))
 }
 
 func TestOIDCRedirectIDTokenClaimsOnlySkipsUserInfo(t *testing.T) {
@@ -220,6 +245,20 @@ func TestOIDCRedirectUserInfoParseFailureRejected(t *testing.T) {
 		`{"sub":"user-sub","preferred_username":"test_oidc_ui_user"}`, ui, nil, false)
 	assert.Equal(t, http.StatusFound, rr.Code)
 	assert.Equal(t, webClientLoginPath, rr.Header().Get("Location"))
+}
+
+func TestOIDCResolveClaimsNoEndpointSkipsUserInfo(t *testing.T) {
+	// No advertised endpoint: use id token claims without querying, even though the
+	// available UserInfo response has a mismatched subject that would otherwise reject.
+	ui := &oidc.UserInfo{Subject: "other-sub"}
+	setUserInfoClaims(ui, []byte(`{"sub":"other-sub","preferred_username":"attacker"}`))
+	o := OIDC{ClientID: "test-client", userInfoFetcher: &mockOIDCUserInfoFetcher{userInfo: ui, noEndpoint: true}}
+
+	idToken := &oidc.IDToken{Subject: "user-sub"}
+	idClaims := map[string]any{"sub": "user-sub", "preferred_username": "u"}
+	merged, err := o.resolveClaims(context.Background(), idToken, idClaims, &oauth2.Token{AccessToken: "at"})
+	require.NoError(t, err)
+	assert.Equal(t, "u", merged["preferred_username"])
 }
 
 func TestOIDCRoleFromUserInfo(t *testing.T) {
@@ -312,6 +351,7 @@ func TestOIDCLoginLogout(t *testing.T) {
 	server := getTestOIDCServer()
 	err := server.binding.OIDC.initialize()
 	assert.NoError(t, err)
+	server.binding.OIDC.userInfoFetcher = &echoUserInfoFetcher{oidc: &server.binding.OIDC}
 	err = server.initializeRouter()
 	require.NoError(t, err)
 
@@ -735,6 +775,7 @@ func TestOIDCLoginNextRedirect(t *testing.T) {
 	server := getTestOIDCServer()
 	err := server.binding.OIDC.initialize()
 	assert.NoError(t, err)
+	server.binding.OIDC.userInfoFetcher = &echoUserInfoFetcher{oidc: &server.binding.OIDC}
 	err = server.initializeRouter()
 	require.NoError(t, err)
 
@@ -1088,6 +1129,7 @@ func TestValidateOIDCToken(t *testing.T) {
 	server := getTestOIDCServer()
 	err := server.binding.OIDC.initialize()
 	assert.NoError(t, err)
+	server.binding.OIDC.userInfoFetcher = &echoUserInfoFetcher{oidc: &server.binding.OIDC}
 	err = server.initializeRouter()
 	require.NoError(t, err)
 
@@ -1290,6 +1332,7 @@ func TestOIDCImplicitRoles(t *testing.T) {
 	server.binding.OIDC.ImplicitRoles = true
 	err := server.binding.OIDC.initialize()
 	assert.NoError(t, err)
+	server.binding.OIDC.userInfoFetcher = &echoUserInfoFetcher{oidc: &server.binding.OIDC}
 	err = server.initializeRouter()
 	require.NoError(t, err)
 
@@ -1564,6 +1607,7 @@ func TestOIDCEvMgrIntegration(t *testing.T) {
 	server.binding.OIDC.CustomFields = []string{"custom1.sub", "custom2"}
 	err = server.binding.OIDC.initialize()
 	assert.NoError(t, err)
+	server.binding.OIDC.userInfoFetcher = &echoUserInfoFetcher{oidc: &server.binding.OIDC}
 	err = server.initializeRouter()
 	require.NoError(t, err)
 	// login a user with OIDC
@@ -1702,6 +1746,7 @@ func TestOIDCPreLoginHook(t *testing.T) {
 	server.binding.OIDC.CustomFields = []string{"field1", "field2"}
 	err = server.binding.OIDC.initialize()
 	assert.NoError(t, err)
+	server.binding.OIDC.userInfoFetcher = &echoUserInfoFetcher{oidc: &server.binding.OIDC}
 	err = server.initializeRouter()
 	require.NoError(t, err)
 
@@ -1879,6 +1924,7 @@ func TestOIDCWithLoginFormsDisabled(t *testing.T) {
 	server.binding.EnableWebClient = true
 	err := server.binding.OIDC.initialize()
 	assert.NoError(t, err)
+	server.binding.OIDC.userInfoFetcher = &echoUserInfoFetcher{oidc: &server.binding.OIDC}
 	err = server.initializeRouter()
 	require.NoError(t, err)
 	// login with an admin user

--- a/internal/httpd/oidc_test.go
+++ b/internal/httpd/oidc_test.go
@@ -88,14 +88,183 @@ func (v *mockOIDCVerifier) Verify(_ context.Context, _ string) (*oidc.IDToken, e
 	return v.token, v.err
 }
 
-// hack because the field is unexported
-func setIDTokenClaims(idToken *oidc.IDToken, claims []byte) {
-	pointerVal := reflect.ValueOf(idToken)
-	val := reflect.Indirect(pointerVal)
-	member := val.FieldByName("claims")
-	ptr := unsafe.Pointer(member.UnsafeAddr())
-	realPtr := (*[]byte)(ptr)
-	*realPtr = claims
+type mockOIDCUserInfoFetcher struct {
+	userInfo *oidc.UserInfo
+	err      error
+}
+
+func (f *mockOIDCUserInfoFetcher) UserInfo(_ context.Context, _ oauth2.TokenSource) (*oidc.UserInfo, error) {
+	return f.userInfo, f.err
+}
+
+// setClaims writes the raw claims payload into the unexported "claims" field that
+// oidc.IDToken and oidc.UserInfo read in their Claims methods.
+func setClaims(v any, claims []byte) {
+	member := reflect.Indirect(reflect.ValueOf(v)).FieldByName("claims")
+	*(*[]byte)(unsafe.Pointer(member.UnsafeAddr())) = claims
+}
+
+func setUserInfoClaims(ui *oidc.UserInfo, claims []byte) { setClaims(ui, claims) }
+
+func setIDTokenClaims(idToken *oidc.IDToken, claims []byte) { setClaims(idToken, claims) }
+
+func TestMergeOIDCClaims(t *testing.T) {
+	merged := mergeOIDCClaims(
+		map[string]any{"email": "old@example.com", "name": "Old"},
+		map[string]any{"email": "new@example.com"},
+	)
+	assert.Equal(t, "new@example.com", merged["email"])
+	assert.Equal(t, "Old", merged["name"])
+	merged = mergeOIDCClaims(
+		map[string]any{"name": "Old"},
+		map[string]any{"email": "new@example.com"},
+	)
+	assert.Equal(t, "new@example.com", merged["email"])
+	assert.Equal(t, "Old", merged["name"])
+	merged = mergeOIDCClaims(map[string]any{"name": "Old"}, nil)
+	assert.Equal(t, "Old", merged["name"])
+	assert.Len(t, merged, 1)
+	merged = mergeOIDCClaims(nil, map[string]any{"email": "e@example.com"})
+	assert.Equal(t, "e@example.com", merged["email"])
+}
+
+func oidcRedirectHarness(t *testing.T, username, idClaims string, ui *oidc.UserInfo,
+	uiErr error, idTokenClaimsOnly bool,
+) *httptest.ResponseRecorder {
+	t.Helper()
+	tokenValidationMode = 2
+	server := getTestOIDCServer()
+	require.NoError(t, server.binding.OIDC.initialize())
+	require.NoError(t, server.initializeRouter())
+	server.binding.OIDC.IDTokenClaimsOnly = idTokenClaimsOnly
+
+	user := dataprovider.User{
+		BaseUser: sdk.BaseUser{
+			Username:    username,
+			Password:    "pwd",
+			HomeDir:     filepath.Join(os.TempDir(), username),
+			Status:      1,
+			Permissions: map[string][]string{"/": {dataprovider.PermAny}},
+		},
+	}
+	_ = dataprovider.DeleteUser(username, "", "", "")
+	require.NoError(t, dataprovider.AddUser(&user, "", "", ""))
+	t.Cleanup(func() {
+		_ = dataprovider.DeleteUser(username, "", "", "")
+		if mgr, ok := oidcMgr.(*memoryOIDCManager); ok {
+			for k := range mgr.tokens {
+				mgr.removeToken(k)
+			}
+		}
+	})
+
+	token := (&oauth2.Token{AccessToken: "at", Expiry: time.Now().Add(5 * time.Minute)}).
+		WithExtra(map[string]any{"id_token": "id_token_val"})
+	server.binding.OIDC.oauth2Config = &mockOAuth2Config{
+		tokenSource: &mockTokenSource{token: token},
+		authCodeURL: webOIDCRedirectPath,
+		token:       token,
+	}
+
+	authReq := newOIDCPendingAuth(tokenAudienceWebClient)
+	oidcMgr.addPendingAuth(authReq)
+	idToken := &oidc.IDToken{Nonce: authReq.Nonce, Subject: "user-sub", Expiry: time.Now().Add(5 * time.Minute)}
+	setIDTokenClaims(idToken, []byte(idClaims))
+	server.binding.OIDC.verifier = &mockOIDCVerifier{token: idToken}
+	server.binding.OIDC.userInfoFetcher = &mockOIDCUserInfoFetcher{userInfo: ui, err: uiErr}
+
+	rr := httptest.NewRecorder()
+	r, err := http.NewRequest(http.MethodGet, webOIDCRedirectPath+"?state="+authReq.State, nil)
+	require.NoError(t, err)
+	server.router.ServeHTTP(rr, r)
+	return rr
+}
+
+func TestOIDCRedirectUserInfoMerge(t *testing.T) {
+	ui := &oidc.UserInfo{Subject: "user-sub"}
+	setUserInfoClaims(ui, []byte(`{"sub":"user-sub","preferred_username":"test_oidc_ui_user"}`))
+	rr := oidcRedirectHarness(t, "test_oidc_ui_user", `{"sub":"user-sub"}`, ui, nil, false)
+	assert.Equal(t, http.StatusFound, rr.Code, rr.Body.String())
+	assert.Equal(t, webClientFilesPath, rr.Header().Get("Location"))
+}
+
+func TestOIDCRedirectSubMismatchRejected(t *testing.T) {
+	ui := &oidc.UserInfo{Subject: "other-sub"}
+	setUserInfoClaims(ui, []byte(`{"sub":"other-sub","preferred_username":"test_oidc_ui_user"}`))
+	rr := oidcRedirectHarness(t, "test_oidc_ui_user", `{"sub":"user-sub"}`, ui, nil, false)
+	assert.Equal(t, http.StatusFound, rr.Code)
+	assert.Equal(t, webClientLoginPath, rr.Header().Get("Location"))
+}
+
+func TestOIDCRedirectUserInfoErrorFallsBack(t *testing.T) {
+	rr := oidcRedirectHarness(t, "test_oidc_ui_user",
+		`{"sub":"user-sub","preferred_username":"test_oidc_ui_user"}`,
+		nil, fmt.Errorf("userinfo unreachable"), false)
+	assert.Equal(t, http.StatusFound, rr.Code, rr.Body.String())
+	assert.Equal(t, webClientFilesPath, rr.Header().Get("Location"))
+}
+
+func TestOIDCRedirectIDTokenClaimsOnlySkipsUserInfo(t *testing.T) {
+	ui := &oidc.UserInfo{Subject: "other-sub"}
+	setUserInfoClaims(ui, []byte(`{"sub":"other-sub"}`))
+	rr := oidcRedirectHarness(t, "test_oidc_ui_user",
+		`{"sub":"user-sub","preferred_username":"test_oidc_ui_user"}`, ui, nil, true)
+	assert.Equal(t, http.StatusFound, rr.Code, rr.Body.String())
+	assert.Equal(t, webClientFilesPath, rr.Header().Get("Location"))
+}
+
+func TestOIDCRedirectUserInfoParseFailureRejected(t *testing.T) {
+	ui := &oidc.UserInfo{Subject: "user-sub"}
+	setUserInfoClaims(ui, []byte(`{not valid json`))
+	rr := oidcRedirectHarness(t, "test_oidc_ui_user",
+		`{"sub":"user-sub","preferred_username":"test_oidc_ui_user"}`, ui, nil, false)
+	assert.Equal(t, http.StatusFound, rr.Code)
+	assert.Equal(t, webClientLoginPath, rr.Header().Get("Location"))
+}
+
+func TestOIDCRoleFromUserInfo(t *testing.T) {
+	ui := &oidc.UserInfo{Subject: "user-sub"}
+	setUserInfoClaims(ui, []byte(`{"sub":"user-sub","preferred_username":"u","sftpgo_role":"admin"}`))
+	o := OIDC{ClientID: "test-client", userInfoFetcher: &mockOIDCUserInfoFetcher{userInfo: ui}}
+
+	idToken := &oidc.IDToken{Subject: "user-sub"}
+	idClaims := map[string]any{"sub": "user-sub", "preferred_username": "u"}
+	merged, err := o.resolveClaims(context.Background(), idToken, idClaims, &oauth2.Token{AccessToken: "at"})
+	require.NoError(t, err)
+
+	var token oidcToken
+	require.NoError(t, token.parseClaims(merged, "preferred_username", "sftpgo_role", nil, ""))
+	assert.True(t, token.isAdmin())
+}
+
+func TestOIDCResolveClaimsRealUserInfo(t *testing.T) {
+	var issuer string
+	mux := http.NewServeMux()
+	mux.HandleFunc("/.well-known/openid-configuration", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprintf(w, `{"issuer":%q,"authorization_endpoint":%q,"token_endpoint":%q,"userinfo_endpoint":%q,"jwks_uri":%q}`,
+			issuer, issuer+"/auth", issuer+"/token", issuer+"/userinfo", issuer+"/keys")
+	})
+	mux.HandleFunc("/userinfo", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprintf(w, `{"sub":"user-sub","preferred_username":"real_ui_user","email":"real@example.com"}`)
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+	issuer = srv.URL
+
+	o := OIDC{ClientID: "test-client"}
+	provider, err := oidc.NewProvider(context.Background(), issuer)
+	require.NoError(t, err)
+	o.provider = provider
+
+	idToken := &oidc.IDToken{Subject: "user-sub"}
+	idClaims := map[string]any{"sub": "user-sub", "sftpgo_role": "admin"}
+	merged, err := o.resolveClaims(context.Background(), idToken, idClaims, &oauth2.Token{AccessToken: "at"})
+	require.NoError(t, err)
+	assert.Equal(t, "real_ui_user", merged["preferred_username"])
+	assert.Equal(t, "real@example.com", merged["email"])
+	assert.Equal(t, "admin", merged["sftpgo_role"])
 }
 
 func TestOIDCInitialization(t *testing.T) {

--- a/sftpgo.json
+++ b/sftpgo.json
@@ -304,6 +304,7 @@
           "role_field": "",
           "implicit_roles": false,
           "custom_fields": [],
+          "id_token_claims_only": false,
           "insecure_skip_signature_check": false,
           "debug": false
         },


### PR DESCRIPTION
This is something that's niggled me ever since I set up SFTPGo and discovered it was one of the handful of OIDC clients that hasn't quite faithfully implemented the OIDC spec and needs a workaround.

As per [OIDC Core §5.3](https://openid.net/specs/openid-connect-core-1_0.html#UserInfo), the authoritative way to receive OIDC claims is through the userinfo endpoint. Currently, SFTPGo doesn't query this, and relies on all claims being shoved into the token.

So, I've gone ahead and added userinfo reading to the OIDC client implementation. Specifically, unless `id_token_claims_only` is set (only needed in case of broken OIDC providers), we try to access the userinfo endpoint, and upon a response:
- check that the response is valid, otherwise abort the login (something is wrong)
- merge the userinfo claims with the token's

It goes without saying that auth needs to be handled with care; this isn't the first time I've contributed OIDC improvements. I've upstreamed OIDC implementations/improvements to a handful of projects at this point, and consulted the Authelia maintainer to make sure I had the right understanding of how token/userinfo merging should be handled and what's a decent approach to non-conformant OIDC providers.

I got an LLM to both help with reviewing this work, and also write tests for it.

Closes #2265

## Checklist for Pull Requests

- [x] Have you signed the [Contributor License Agreement](https://sftpgo.com/cla.html)?
