### PR TITLE
Backport "Fix/ftp active connection (#2164)" to 2.7.x feature branch

### DIFF
--- a/internal/common/common.go
+++ b/internal/common/common.go
@@ -1194,7 +1194,7 @@ func (conns *ActiveConnections) checkIdles() {
 				logger.Debug(conn.GetProtocol(), conn.GetID(), "close idle connection, idle time: %s, username: %q close err: %v",
 					time.Since(conn.GetLastActivity()), conn.GetUsername(), err)
 			}(c)
-		} else if !c.isAccessAllowed() {
+		} else if !isUnauthenticatedFTPUser && !c.isAccessAllowed() {
 			defer func(conn ActiveConnection) {
 				err := conn.Disconnect()
 				logger.Info(conn.GetProtocol(), conn.GetID(), "access conditions not met for user: %q close connection err: %v",

--- a/internal/common/common_test.go
+++ b/internal/common/common_test.go
@@ -828,11 +828,7 @@ func TestIdleConnections(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, Connections.GetActiveSessions(username), 2)
 
-	cFTP := NewBaseConnection("id2", ProtocolFTP, "", "", dataprovider.User{
-		BaseUser: sdk.BaseUser{
-			Status: 1,
-		},
-	})
+	cFTP := NewBaseConnection("id2", ProtocolFTP, "", "", dataprovider.User{})
 	cFTP.lastActivity.Store(time.Now().UnixNano())
 	fakeConn = &fakeConnection{
 		BaseConnection: cFTP,


### PR DESCRIPTION
Backport of #2164 so the fix ships in the 2.7.x line

ftpd: avoid fresh ftp connection being closed

(cherry picked from commit 133d2692c445d3486fcdd931e32f03226a0c8278)

# Checklist for Pull Requests

- [x] Have you signed the [Contributor License Agreement](https://sftpgo.com/cla.html)?

---
