### PR TITLE
defender: correct misleading score/threshold validation error

### DIFF
--- a/internal/common/defender.go
+++ b/internal/common/defender.go
@@ -225,16 +225,16 @@ func (c *DefenderConfig) validate() error {
 		return err
 	}
 	if c.ScoreInvalid >= c.Threshold {
-		return fmt.Errorf("score_invalid %d cannot be greater than threshold %d", c.ScoreInvalid, c.Threshold)
+		return fmt.Errorf("score_invalid %d must be lower than threshold %d", c.ScoreInvalid, c.Threshold)
 	}
 	if c.ScoreValid >= c.Threshold {
-		return fmt.Errorf("score_valid %d cannot be greater than threshold %d", c.ScoreValid, c.Threshold)
+		return fmt.Errorf("score_valid %d must be lower than threshold %d", c.ScoreValid, c.Threshold)
 	}
 	if c.ScoreLimitExceeded >= c.Threshold {
-		return fmt.Errorf("score_limit_exceeded %d cannot be greater than threshold %d", c.ScoreLimitExceeded, c.Threshold)
+		return fmt.Errorf("score_limit_exceeded %d must be lower than threshold %d", c.ScoreLimitExceeded, c.Threshold)
 	}
 	if c.ScoreNoAuth >= c.Threshold {
-		return fmt.Errorf("score_no_auth %d cannot be greater than threshold %d", c.ScoreNoAuth, c.Threshold)
+		return fmt.Errorf("score_no_auth %d must be lower than threshold %d", c.ScoreNoAuth, c.Threshold)
 	}
 	if c.BanTime <= 0 {
 		return fmt.Errorf("invalid ban_time %v", c.BanTime)

--- a/internal/common/defender_test.go
+++ b/internal/common/defender_test.go
@@ -470,6 +470,9 @@ func TestDefenderConfig(t *testing.T) {
 	c.ScoreInvalid = 10
 	err = c.validate()
 	require.Error(t, err)
+	// a score equal to the threshold must be rejected and the error must not
+	// claim the score is "greater than" a value it is actually equal to
+	assert.Contains(t, err.Error(), "score_invalid 10 must be lower than threshold 10")
 
 	c.ScoreInvalid = 2
 	c.ScoreLimitExceeded = 10


### PR DESCRIPTION
# Checklist for Pull Requests

- [x] Have you signed the [Contributor License Agreement](https://sftpgo.com/cla.html)?

---

## Problem

`DefenderConfig.validate()` rejects a score that is greater than **or equal to** the threshold, but the error message says only "greater than":

```go
if c.ScoreInvalid >= c.Threshold {
    return fmt.Errorf("score_invalid %d cannot be greater than threshold %d", c.ScoreInvalid, c.Threshold)
}
```

So configuring `score_invalid = 10` with `threshold = 10` fails with:

```
score_invalid 10 cannot be greater than threshold 10
```

which tells the operator that 10 is greater than 10. The value is rejected for a real reason, the message just describes the wrong one, and it gives no hint that the fix is to lower the score below the threshold.

## Fix

Reworded all four messages (`score_invalid`, `score_valid`, `score_limit_exceeded`, `score_no_auth`) from "cannot be greater than threshold" to "must be lower than threshold", which matches what the `>=` check actually enforces. No behaviour change, only the message.

## Tests

`TestDefenderConfig` already exercised the equal-to-threshold case but only asserted that an error was returned, so the wording was untested. Added an assertion on the message for that case. It fails before the change and passes after; `go test ./internal/common/ -run TestDefenderConfig` is green.

## AI disclosure

Written with Claude (Claude Code). I verified the failing-before and passing-after states locally.