### PR TITLE
atomic upload: do not reuse the target file record on overwrite

### DIFF
--- a/internal/ftpd/handler.go
+++ b/internal/ftpd/handler.go
@@ -476,9 +476,16 @@ func (c *Connection) handleFTPUploadToExistingFile(fs vfs.Fs, flags int, resolve
 	// - os.O_WRONLY | os.O_CREATE | os.O_TRUNC if the command is not APPE and REST = 0
 	// so if we don't have O_TRUNC is a resume.
 	isResume := flags&os.O_TRUNC == 0
+	// A resumed upload continues on the existing file via the rename-aside path and thus
+	// reuses the target's file record, writing through any hard link of it. In atomic
+	// mode without resume support there is no safe way to do this, so reject the resume.
+	uploadResumeSupported := vfs.IsUploadResumeSupported(fs, fileSize)
+	if common.Config.IsAtomicUploadEnabled() && common.Config.UploadMode&common.UploadModeAtomicWithResume == 0 {
+		uploadResumeSupported = false
+	}
 	// if there is a size limit remaining size cannot be 0 here, since quotaResult.HasSpace
 	// will return false in this case and we deny the upload before
-	maxWriteSize, err := c.GetMaxWriteSize(diskQuota, isResume, fileSize, vfs.IsUploadResumeSupported(fs, fileSize))
+	maxWriteSize, err := c.GetMaxWriteSize(diskQuota, isResume, fileSize, uploadResumeSupported)
 	if err != nil {
 		c.Log(logger.LevelDebug, "unable to get max write size: %v", err)
 		return nil, err

--- a/internal/ftpd/handler.go
+++ b/internal/ftpd/handler.go
@@ -488,7 +488,11 @@ func (c *Connection) handleFTPUploadToExistingFile(fs vfs.Fs, flags int, resolve
 		return nil, ftpserver.ErrFileNameNotAllowed
 	}
 
-	if common.Config.IsAtomicUploadEnabled() && fs.IsAtomicUploadSupported() {
+	// only a resume needs the existing file moved to the temp path (the upload
+	// continues on its bytes). A plain overwrite must upload into a fresh file record:
+	// renaming the target aside and writing into it propagates the write through every
+	// NTFS hardlink of that record (shared game-content store).
+	if isResume && common.Config.IsAtomicUploadEnabled() && fs.IsAtomicUploadSupported() {
 		_, _, err = fs.Rename(resolvedPath, filePath, 0)
 		if err != nil {
 			c.Log(logger.LevelError, "error renaming existing file for atomic upload, source: %q, dest: %q, err: %+v",

--- a/internal/httpd/handler.go
+++ b/internal/httpd/handler.go
@@ -194,14 +194,9 @@ func (c *Connection) getFileWriter(name string) (io.WriteCloser, error) {
 		return nil, c.GetPermissionDeniedError()
 	}
 
-	if common.Config.IsAtomicUploadEnabled() && fs.IsAtomicUploadSupported() {
-		_, _, err = fs.Rename(p, filePath, 0)
-		if err != nil {
-			c.Log(logger.LevelError, "error renaming existing file for atomic upload, source: %q, dest: %q, err: %+v",
-				p, filePath, err)
-			return nil, c.GetFsError(fs, err)
-		}
-	}
+	// HTTP overwrites are always full uploads — upload into a fresh file record
+	// instead of renaming the target aside, so NTFS hardlinks of the target (shared
+	// game-content store) are never written through.
 
 	return c.handleUploadFile(fs, p, filePath, name, false, stat.Size())
 }

--- a/internal/sftpd/handler.go
+++ b/internal/sftpd/handler.go
@@ -472,7 +472,10 @@ func (c *Connection) handleSFTPUploadToExistingFile(fs vfs.Fs, pflags sftp.FileO
 		return nil, c.GetPermissionDeniedError()
 	}
 
-	if common.Config.IsAtomicUploadEnabled() && fs.IsAtomicUploadSupported() {
+	// only a resume/non-truncating open needs the existing file at the temp path.
+	// A truncating overwrite uploads into a fresh file record so NTFS hardlinks of the
+	// target (shared game-content store) are never written through.
+	if isResume && common.Config.IsAtomicUploadEnabled() && fs.IsAtomicUploadSupported() {
 		_, _, err = fs.Rename(resolvedPath, filePath, 0)
 		if err != nil {
 			c.Log(logger.LevelError, "error renaming existing file for atomic upload, source: %q, dest: %q, err: %+v",

--- a/internal/sftpd/scp.go
+++ b/internal/sftpd/scp.go
@@ -334,15 +334,9 @@ func (c *scpCommand) handleUpload(uploadFilePath string, sizeToRead int64) error
 		return common.ErrPermissionDenied
 	}
 
-	if common.Config.IsAtomicUploadEnabled() && fs.IsAtomicUploadSupported() {
-		_, _, err = fs.Rename(p, filePath, 0)
-		if err != nil {
-			c.connection.Log(logger.LevelError, "error renaming existing file for atomic upload, source: %q, dest: %q, err: %v",
-				p, filePath, err)
-			c.sendErrorMessage(fs, err)
-			return err
-		}
-	}
+	// scp overwrites are always full uploads — upload into a fresh file record
+	// instead of renaming the target aside, so NTFS hardlinks of the target (shared
+	// game-content store) are never written through.
 
 	return c.handleUploadFile(fs, p, filePath, sizeToRead, false, stat.Size(), uploadFilePath)
 }

--- a/internal/webdavd/handler.go
+++ b/internal/webdavd/handler.go
@@ -272,14 +272,9 @@ func (c *Connection) handleUploadToExistingFile(fs vfs.Fs, resolvedPath, filePat
 	// will return false in this case and we deny the upload before
 	maxWriteSize, _ := c.GetMaxWriteSize(diskQuota, false, fileSize, fs.IsUploadResumeSupported())
 
-	if common.Config.IsAtomicUploadEnabled() && fs.IsAtomicUploadSupported() {
-		_, _, err = fs.Rename(resolvedPath, filePath, 0)
-		if err != nil {
-			c.Log(logger.LevelError, "error renaming existing file for atomic upload, source: %q, dest: %q, err: %+v",
-				resolvedPath, filePath, err)
-			return nil, c.GetFsError(fs, err)
-		}
-	}
+	// WebDAV overwrites are always full uploads — upload into a fresh file record
+	// instead of renaming the target aside, so NTFS hardlinks of the target (shared
+	// game-content store) are never written through.
 
 	file, w, cancelFn, err := fs.Create(filePath, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, c.GetCreateChecks(requestPath, false, false))
 	if err != nil {


### PR DESCRIPTION
# Checklist for Pull Requests

- [ ] Have you signed the [Contributor License Agreement](https://sftpgo.com/cla.html)?

---

Atomic uploads currently rename the existing target to the temporary name and write into it, which reuses the target's file record (inode). When the target has multiple hard links, the uploaded content becomes visible through every other link of that record.

We run SFTPGo on Windows hosts where identical content is deduplicated across tenants via NTFS hardlinks. One tenant overwriting a file via FTP replaced the content for every tenant sharing that record (verified via the NTFS USN journal: rename to `.sftpgo-upload.*`, truncate and write on the same file id, rename back).

This change uploads non-resumed overwrites into a fresh temporary file instead; the existing completion path renames it over the target. The rename-aside is kept for resumed uploads, which must continue on the existing bytes. Side effect: if an atomic upload fails, the original target now remains intact instead of being renamed aside and deleted along with the temporary file.

Tested on macOS/APFS and Windows Server 2016/NTFS: the hardlinked target keeps inode and content, the uploader gets a fresh inode. Happy to gate this behind a config option if you prefer to keep the current behavior as default.
