### PR TITLE
dataprovider: log the source IP for authentication errors

### DIFF
--- a/internal/dataprovider/bolt.go
+++ b/internal/dataprovider/bolt.go
@@ -108,14 +108,14 @@ func (p *BoltProvider) checkAvailability() error {
 	return err
 }
 
-func (p *BoltProvider) validateUserAndTLSCert(username, protocol string, tlsCert *x509.Certificate) (User, error) {
+func (p *BoltProvider) validateUserAndTLSCert(username, ip, protocol string, tlsCert *x509.Certificate) (User, error) {
 	var user User
 	if tlsCert == nil {
 		return user, errors.New("TLS certificate cannot be null or empty")
 	}
 	user, err := p.userExists(username, "")
 	if err != nil {
-		providerLog(logger.LevelWarn, "error authenticating user %q: %v", username, err)
+		providerLog(logger.LevelWarn, "error authenticating user %q from IP %q: %v", username, ip, err)
 		return user, err
 	}
 	return checkUserAndTLSCertificate(&user, protocol, tlsCert)
@@ -124,7 +124,7 @@ func (p *BoltProvider) validateUserAndTLSCert(username, protocol string, tlsCert
 func (p *BoltProvider) validateUserAndPass(username, password, ip, protocol string) (User, error) {
 	user, err := p.userExists(username, "")
 	if err != nil {
-		providerLog(logger.LevelWarn, "error authenticating user %q: %v", username, err)
+		providerLog(logger.LevelWarn, "error authenticating user %q from IP %q: %v", username, ip, err)
 		return user, err
 	}
 	return checkUserAndPass(&user, password, ip, protocol)
@@ -133,21 +133,21 @@ func (p *BoltProvider) validateUserAndPass(username, password, ip, protocol stri
 func (p *BoltProvider) validateAdminAndPass(username, password, ip string) (Admin, error) {
 	admin, err := p.adminExists(username)
 	if err != nil {
-		providerLog(logger.LevelWarn, "error authenticating admin %q: %v", username, err)
+		providerLog(logger.LevelWarn, "error authenticating admin %q from IP %q: %v", username, ip, err)
 		return admin, err
 	}
 	err = admin.checkUserAndPass(password, ip)
 	return admin, err
 }
 
-func (p *BoltProvider) validateUserAndPubKey(username string, pubKey []byte, isSSHCert bool) (User, string, error) {
+func (p *BoltProvider) validateUserAndPubKey(username string, pubKey []byte, ip string, isSSHCert bool) (User, string, error) {
 	var user User
 	if len(pubKey) == 0 {
 		return user, "", errors.New("credentials cannot be null or empty")
 	}
 	user, err := p.userExists(username, "")
 	if err != nil {
-		providerLog(logger.LevelWarn, "error authenticating user %q: %v", username, err)
+		providerLog(logger.LevelWarn, "error authenticating user %q from IP %q: %v", username, ip, err)
 		return user, "", err
 	}
 	return checkUserAndPubKey(&user, pubKey, isSSHCert)

--- a/internal/dataprovider/dataprovider.go
+++ b/internal/dataprovider/dataprovider.go
@@ -770,8 +770,8 @@ func HasUsersBaseDir() bool {
 // Provider defines the interface that data providers must implement.
 type Provider interface {
 	validateUserAndPass(username, password, ip, protocol string) (User, error)
-	validateUserAndPubKey(username string, pubKey []byte, isSSHCert bool) (User, string, error)
-	validateUserAndTLSCert(username, protocol string, tlsCert *x509.Certificate) (User, error)
+	validateUserAndPubKey(username string, pubKey []byte, ip string, isSSHCert bool) (User, string, error)
+	validateUserAndTLSCert(username, ip, protocol string, tlsCert *x509.Certificate) (User, error)
 	updateQuota(username string, filesAdd int, sizeAdd int64, reset bool) error
 	updateTransferQuota(username string, uploadSize, downloadSize int64, reset bool) error
 	getUsedQuota(username string) (int, int64, int64, int64, error)
@@ -1316,7 +1316,7 @@ func CheckUserAndTLSCert(username, ip, protocol string, tlsCert *x509.Certificat
 		}
 		return checkUserAndTLSCertificate(&user, protocol, tlsCert)
 	}
-	return provider.validateUserAndTLSCert(username, protocol, tlsCert)
+	return provider.validateUserAndTLSCert(username, ip, protocol, tlsCert)
 }
 
 // CheckUserAndPass retrieves the SFTPGo user with the given username and password if a match is found or an error
@@ -1370,7 +1370,7 @@ func CheckUserAndPubKey(username string, pubKey []byte, ip, protocol string, isS
 		}
 		return checkUserAndPubKey(&user, pubKey, isSSHCert)
 	}
-	return provider.validateUserAndPubKey(username, pubKey, isSSHCert)
+	return provider.validateUserAndPubKey(username, pubKey, ip, isSSHCert)
 }
 
 // CheckKeyboardInteractiveAuth checks the keyboard interactive authentication and returns

--- a/internal/dataprovider/memory.go
+++ b/internal/dataprovider/memory.go
@@ -148,14 +148,14 @@ func (p *MemoryProvider) close() error {
 	return nil
 }
 
-func (p *MemoryProvider) validateUserAndTLSCert(username, protocol string, tlsCert *x509.Certificate) (User, error) {
+func (p *MemoryProvider) validateUserAndTLSCert(username, ip, protocol string, tlsCert *x509.Certificate) (User, error) {
 	var user User
 	if tlsCert == nil {
 		return user, errors.New("TLS certificate cannot be null or empty")
 	}
 	user, err := p.userExists(username, "")
 	if err != nil {
-		providerLog(logger.LevelWarn, "error authenticating user %q: %v", username, err)
+		providerLog(logger.LevelWarn, "error authenticating user %q from IP %q: %v", username, ip, err)
 		return user, err
 	}
 	return checkUserAndTLSCertificate(&user, protocol, tlsCert)
@@ -164,20 +164,20 @@ func (p *MemoryProvider) validateUserAndTLSCert(username, protocol string, tlsCe
 func (p *MemoryProvider) validateUserAndPass(username, password, ip, protocol string) (User, error) {
 	user, err := p.userExists(username, "")
 	if err != nil {
-		providerLog(logger.LevelWarn, "error authenticating user %q: %v", username, err)
+		providerLog(logger.LevelWarn, "error authenticating user %q from IP %q: %v", username, ip, err)
 		return user, err
 	}
 	return checkUserAndPass(&user, password, ip, protocol)
 }
 
-func (p *MemoryProvider) validateUserAndPubKey(username string, pubKey []byte, isSSHCert bool) (User, string, error) {
+func (p *MemoryProvider) validateUserAndPubKey(username string, pubKey []byte, ip string, isSSHCert bool) (User, string, error) {
 	var user User
 	if len(pubKey) == 0 {
 		return user, "", errors.New("credentials cannot be null or empty")
 	}
 	user, err := p.userExists(username, "")
 	if err != nil {
-		providerLog(logger.LevelWarn, "error authenticating user %q: %v", username, err)
+		providerLog(logger.LevelWarn, "error authenticating user %q from IP %q: %v", username, ip, err)
 		return user, "", err
 	}
 	return checkUserAndPubKey(&user, pubKey, isSSHCert)
@@ -186,7 +186,7 @@ func (p *MemoryProvider) validateUserAndPubKey(username string, pubKey []byte, i
 func (p *MemoryProvider) validateAdminAndPass(username, password, ip string) (Admin, error) {
 	admin, err := p.adminExists(username)
 	if err != nil {
-		providerLog(logger.LevelWarn, "error authenticating admin %q: %v", username, err)
+		providerLog(logger.LevelWarn, "error authenticating admin %q from IP %q: %v", username, ip, err)
 		return admin, err
 	}
 	err = admin.checkUserAndPass(password, ip)

--- a/internal/dataprovider/mysql.go
+++ b/internal/dataprovider/mysql.go
@@ -371,12 +371,12 @@ func (p *MySQLProvider) validateUserAndPass(username, password, ip, protocol str
 	return sqlCommonValidateUserAndPass(username, password, ip, protocol, p.dbHandle)
 }
 
-func (p *MySQLProvider) validateUserAndTLSCert(username, protocol string, tlsCert *x509.Certificate) (User, error) {
-	return sqlCommonValidateUserAndTLSCertificate(username, protocol, tlsCert, p.dbHandle)
+func (p *MySQLProvider) validateUserAndTLSCert(username, ip, protocol string, tlsCert *x509.Certificate) (User, error) {
+	return sqlCommonValidateUserAndTLSCertificate(username, ip, protocol, tlsCert, p.dbHandle)
 }
 
-func (p *MySQLProvider) validateUserAndPubKey(username string, publicKey []byte, isSSHCert bool) (User, string, error) {
-	return sqlCommonValidateUserAndPubKey(username, publicKey, isSSHCert, p.dbHandle)
+func (p *MySQLProvider) validateUserAndPubKey(username string, publicKey []byte, ip string, isSSHCert bool) (User, string, error) {
+	return sqlCommonValidateUserAndPubKey(username, publicKey, ip, isSSHCert, p.dbHandle)
 }
 
 func (p *MySQLProvider) updateTransferQuota(username string, uploadSize, downloadSize int64, reset bool) error {

--- a/internal/dataprovider/pgsql.go
+++ b/internal/dataprovider/pgsql.go
@@ -463,12 +463,12 @@ func (p *PGSQLProvider) validateUserAndPass(username, password, ip, protocol str
 	return sqlCommonValidateUserAndPass(username, password, ip, protocol, p.dbHandle)
 }
 
-func (p *PGSQLProvider) validateUserAndTLSCert(username, protocol string, tlsCert *x509.Certificate) (User, error) {
-	return sqlCommonValidateUserAndTLSCertificate(username, protocol, tlsCert, p.dbHandle)
+func (p *PGSQLProvider) validateUserAndTLSCert(username, ip, protocol string, tlsCert *x509.Certificate) (User, error) {
+	return sqlCommonValidateUserAndTLSCertificate(username, ip, protocol, tlsCert, p.dbHandle)
 }
 
-func (p *PGSQLProvider) validateUserAndPubKey(username string, publicKey []byte, isSSHCert bool) (User, string, error) {
-	return sqlCommonValidateUserAndPubKey(username, publicKey, isSSHCert, p.dbHandle)
+func (p *PGSQLProvider) validateUserAndPubKey(username string, publicKey []byte, ip string, isSSHCert bool) (User, string, error) {
+	return sqlCommonValidateUserAndPubKey(username, publicKey, ip, isSSHCert, p.dbHandle)
 }
 
 func (p *PGSQLProvider) updateTransferQuota(username string, uploadSize, downloadSize int64, reset bool) error {

--- a/internal/dataprovider/sqlcommon.go
+++ b/internal/dataprovider/sqlcommon.go
@@ -425,7 +425,7 @@ func sqlCommonGetAdminByUsername(username string, dbHandle sqlQuerier) (Admin, e
 func sqlCommonValidateAdminAndPass(username, password, ip string, dbHandle *sql.DB) (Admin, error) {
 	admin, err := sqlCommonGetAdminByUsername(username, dbHandle)
 	if err != nil {
-		providerLog(logger.LevelWarn, "error authenticating admin %q: %v", username, err)
+		providerLog(logger.LevelWarn, "error authenticating admin %q from IP %q: %v", username, ip, err)
 		return admin, err
 	}
 	err = admin.checkUserAndPass(password, ip)
@@ -1180,33 +1180,33 @@ func sqlCommonGetUserByUsername(username, role string, dbHandle sqlQuerier) (Use
 func sqlCommonValidateUserAndPass(username, password, ip, protocol string, dbHandle *sql.DB) (User, error) {
 	user, err := sqlCommonGetUserByUsername(username, "", dbHandle)
 	if err != nil {
-		providerLog(logger.LevelWarn, "error authenticating user %q: %v", username, err)
+		providerLog(logger.LevelWarn, "error authenticating user %q from IP %q: %v", username, ip, err)
 		return user, err
 	}
 	return checkUserAndPass(&user, password, ip, protocol)
 }
 
-func sqlCommonValidateUserAndTLSCertificate(username, protocol string, tlsCert *x509.Certificate, dbHandle *sql.DB) (User, error) {
+func sqlCommonValidateUserAndTLSCertificate(username, ip, protocol string, tlsCert *x509.Certificate, dbHandle *sql.DB) (User, error) {
 	var user User
 	if tlsCert == nil {
 		return user, errors.New("TLS certificate cannot be null or empty")
 	}
 	user, err := sqlCommonGetUserByUsername(username, "", dbHandle)
 	if err != nil {
-		providerLog(logger.LevelWarn, "error authenticating user %q: %v", username, err)
+		providerLog(logger.LevelWarn, "error authenticating user %q from IP %q: %v", username, ip, err)
 		return user, err
 	}
 	return checkUserAndTLSCertificate(&user, protocol, tlsCert)
 }
 
-func sqlCommonValidateUserAndPubKey(username string, pubKey []byte, isSSHCert bool, dbHandle *sql.DB) (User, string, error) {
+func sqlCommonValidateUserAndPubKey(username string, pubKey []byte, ip string, isSSHCert bool, dbHandle *sql.DB) (User, string, error) {
 	var user User
 	if len(pubKey) == 0 {
 		return user, "", errors.New("credentials cannot be null or empty")
 	}
 	user, err := sqlCommonGetUserByUsername(username, "", dbHandle)
 	if err != nil {
-		providerLog(logger.LevelWarn, "error authenticating user %q: %v", username, err)
+		providerLog(logger.LevelWarn, "error authenticating user %q from IP %q: %v", username, ip, err)
 		return user, "", err
 	}
 	return checkUserAndPubKey(&user, pubKey, isSSHCert)

--- a/internal/dataprovider/sqlite.go
+++ b/internal/dataprovider/sqlite.go
@@ -479,12 +479,12 @@ func (p *SQLiteProvider) validateUserAndPass(username, password, ip, protocol st
 	return sqlCommonValidateUserAndPass(username, password, ip, protocol, p.dbHandle)
 }
 
-func (p *SQLiteProvider) validateUserAndTLSCert(username, protocol string, tlsCert *x509.Certificate) (User, error) {
-	return sqlCommonValidateUserAndTLSCertificate(username, protocol, tlsCert, p.dbHandle)
+func (p *SQLiteProvider) validateUserAndTLSCert(username, ip, protocol string, tlsCert *x509.Certificate) (User, error) {
+	return sqlCommonValidateUserAndTLSCertificate(username, ip, protocol, tlsCert, p.dbHandle)
 }
 
-func (p *SQLiteProvider) validateUserAndPubKey(username string, publicKey []byte, isSSHCert bool) (User, string, error) {
-	return sqlCommonValidateUserAndPubKey(username, publicKey, isSSHCert, p.dbHandle)
+func (p *SQLiteProvider) validateUserAndPubKey(username string, publicKey []byte, ip string, isSSHCert bool) (User, string, error) {
+	return sqlCommonValidateUserAndPubKey(username, publicKey, ip, isSSHCert, p.dbHandle)
 }
 
 func (p *SQLiteProvider) updateTransferQuota(username string, uploadSize, downloadSize int64, reset bool) error {


### PR DESCRIPTION
# Checklist for Pull Requests

- [ ] Have you signed the [Contributor License Agreement](https://sftpgo.com/cla.html)?

---

## What

The `error authenticating user %q` / `error authenticating admin %q` warnings in `internal/dataprovider` only reported the username. This adds the client IP so failed logins can be correlated with their origin:

```
error authenticating user "bob" from IP "203.0.113.5": no such user
```

## How

- The password-based paths (`validateUserAndPass`, `validateAdminAndPass`) already had `ip` in scope — only the format string changed.
- The TLS certificate and public key paths did not receive the IP at the provider layer, even though `CheckUserAndTLSCert` and `CheckUserAndPubKey` already have it. The parameter is threaded through:
  - the `Provider` interface: `validateUserAndTLSCert(username, ip, protocol string, tlsCert *x509.Certificate)` and `validateUserAndPubKey(username string, pubKey []byte, ip string, isSSHCert bool)`
  - all five implementations (memory, bolt, sqlite, pgsql, mysql) and the shared `sqlCommonValidateUserAndTLSCertificate` / `sqlCommonValidateUserAndPubKey`

Parameter placement follows the existing `validateUserAndPass(username, password, ip, protocol)` convention. All changes are internal — no public API or configuration change.

## Testing

`go build ./...` and `go vet ./...` pass clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)