### PR TITLE
fix(httpd): return 400 when GET /user/dirs path is a file

### DIFF
--- a/internal/httpd/api_http_user.go
+++ b/internal/httpd/api_http_user.go
@@ -72,6 +72,15 @@ func readUserFolder(w http.ResponseWriter, r *http.Request) {
 	defer common.Connections.Remove(connection.GetID())
 
 	name := connection.User.GetCleanedPath(r.URL.Query().Get("path"))
+	info, err := connection.Stat(name, 0)
+	if err != nil {
+		sendAPIResponse(w, r, err, "Unable to get directory lister", getMappedStatusCode(err))
+		return
+	}
+	if !info.IsDir() {
+		sendAPIResponse(w, r, nil, fmt.Sprintf("Please set the path to a valid directory, %q is not a directory", name), http.StatusBadRequest)
+		return
+	}
 	lister, err := connection.ReadDir(name)
 	if err != nil {
 		sendAPIResponse(w, r, err, "Unable to get directory lister", getMappedStatusCode(err))

--- a/internal/vfs/cryptfs.go
+++ b/internal/vfs/cryptfs.go
@@ -24,6 +24,7 @@ import (
 	"io"
 	"net/http"
 	"os"
+	"syscall"
 
 	"github.com/minio/sio"
 
@@ -234,6 +235,16 @@ func (fs *CryptFs) ReadDir(dirname string) (DirLister, error) {
 			err = os.ErrNotExist
 		}
 		return nil, err
+	}
+	fi, err := f.Stat()
+	if err != nil {
+		f.Close()
+		return nil, err
+	}
+	if !fi.IsDir() {
+		name := f.Name()
+		f.Close()
+		return nil, &os.PathError{Op: "readdir", Path: name, Err: syscall.ENOTDIR}
 	}
 
 	return &cryptFsDirLister{f}, nil

--- a/internal/vfs/osfs.go
+++ b/internal/vfs/osfs.go
@@ -25,6 +25,7 @@ import (
 	"path"
 	"path/filepath"
 	"strings"
+	"syscall"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -491,6 +492,16 @@ func (fs *OsFs) ReadDir(dirname string) (DirLister, error) {
 			err = os.ErrNotExist
 		}
 		return nil, err
+	}
+	fi, err := f.Stat()
+	if err != nil {
+		f.Close()
+		return nil, err
+	}
+	if !fi.IsDir() {
+		name := f.Name()
+		f.Close()
+		return nil, &os.PathError{Op: "readdir", Path: name, Err: syscall.ENOTDIR}
 	}
 	return &osFsDirLister{f}, nil
 }

--- a/internal/vfs/osfs_test.go
+++ b/internal/vfs/osfs_test.go
@@ -1,0 +1,53 @@
+// Copyright (C) 2019 Nicola Murino
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published
+// by the Free Software Foundation, version 3.
+
+package vfs
+
+import (
+	"errors"
+	"io"
+	"os"
+	"path/filepath"
+	"syscall"
+	"testing"
+)
+
+func TestOsFsReadDirRejectsRegularFile(t *testing.T) {
+	root := t.TempDir()
+	filePath := filepath.Join(root, "file.mp4")
+	if err := os.WriteFile(filePath, []byte("x"), 0o600); err != nil {
+		t.Fatalf("write file: %v", err)
+	}
+
+	fs := NewOsFs("test-conn", root, "", nil)
+	defer fs.Close()
+
+	lister, err := fs.ReadDir(filePath)
+	if err == nil {
+		_ = lister.Close()
+		t.Fatal("expected ReadDir on a regular file to fail")
+	}
+	var pathErr *os.PathError
+	if !errors.As(err, &pathErr) {
+		t.Fatalf("expected *os.PathError, got %T: %v", err, err)
+	}
+	if !errors.Is(pathErr.Err, syscall.ENOTDIR) {
+		t.Fatalf("expected ENOTDIR, got %v", pathErr.Err)
+	}
+
+	dirLister, err := fs.ReadDir(root)
+	if err != nil {
+		t.Fatalf("ReadDir on directory: %v", err)
+	}
+	defer dirLister.Close()
+	entries, err := dirLister.Next(10)
+	if err != nil && !errors.Is(err, io.EOF) {
+		t.Fatalf("Next: %v", err)
+	}
+	if len(entries) != 1 || entries[0].Name() != "file.mp4" {
+		t.Fatalf("unexpected entries: %+v", entries)
+	}
+}


### PR DESCRIPTION
# Checklist for Pull Requests

- [ ] Have you signed the [Contributor License Agreement](https://sftpgo.com/cla.html)?

---

## Problem

`GET /api/v2/user/dirs?path=/file` for an existing regular file returned HTTP 200 with a truncated `[` body and closed the connection (`curl: (52) Empty reply from server`). Missing paths already returned 404; a file path was indistinguishable from a network failure.

## Cause

`OsFs.ReadDir` / `CryptFs.ReadDir` open the path successfully even when it is a regular file, then fail on the first `Readdir`. `streamJSONArray` had already written status 200 and `[`, so the handler could only abort via `http.ErrAbortHandler`.

## Fix

- Stat the path in `readUserFolder` and return 400 when it is not a directory (same shape as `getUserFile` when the path is a directory).
- Reject non-directories in local `ReadDir` implementations before returning a lister.

## Tests

```
go test ./internal/vfs/ -run TestOsFsReadDirRejectsRegularFile -count=1
```

Fixes #2277
